### PR TITLE
ci: Add ok-to-test label

### DIFF
--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   nvrc-ci-on-push:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Only run GHA when ok-to-test label is present.