### PR TITLE
Update install_rust.sh to handle Miri installation

### DIFF
--- a/tests/install_rust.sh
+++ b/tests/install_rust.sh
@@ -34,5 +34,5 @@ rustup target add "${RUSTARCH}-unknown-linux-musl"
 
 rustup component add rustfmt
 rustup component add clippy
-rustup component add miri
+rustup component add miri || true 
 


### PR DESCRIPTION
Make Miri installation non-blocking by adding '|| true'.