### PR TITLE
ci: Run the "ci-on-push" every night

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -1,0 +1,24 @@
+name: NVRC Nightly CI
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  nvrc-nightly-ci:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/ci.yaml
+    with:
+      commit-hash: ${{ github.sha }}
+      pr-number: "nightly"
+      tag: ${{ github.sha }}-"nightly"
+      target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
This will help us to catch potential vulberabilities found in crates we depend on, as we'll be running the checks every night and not only on PRs (as the volume of PRs on this repo is low).