### PR TITLE
ci: static-checks: Also run nightly

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -8,6 +8,8 @@ on:
       - edited
       - reopened
       - synchronize
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
We should run the static checks nightly so we can ensure that our no CVEs were found on our deps, and if they have been, then we can promptly fix without the need to wait for the next PR to warn us about the issues.