### PR TITLE
mount: Remove unneeded already mounted check

### DIFF
--- a/src/lockdown.rs
+++ b/src/lockdown.rs
@@ -30,7 +30,8 @@ pub fn set_panic_hook() {
 /// Production uses power_off(); tests inject a no-op to avoid rebooting.
 fn set_panic_hook_with<F: Fn() + Send + Sync + 'static>(shutdown: F) {
     panic::set_hook(Box::new(move |panic_info| {
-        log::error!("panic: {panic_info}");
+        // fd 1,2 are always available from the kernel
+        eprintln!("panic: {panic_info}");
         sync();
         shutdown();
     }));

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,8 @@ fn main() {
     lockdown::set_panic_hook();
     let mut init = NVRC::default();
     must!(mount::setup());
-    must!(syslog::poll());
     must!(kmsg::kernlog_setup());
+    must!(syslog::poll());
     must!(mount::readonly("/"));
     must!(init.process_kernel_params(None));
 

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -2,48 +2,24 @@
 // Copyright (c) NVIDIA CORPORATION
 
 //! Filesystem setup for the minimal init environment.
-//!
-//! Coverage note: ~80% is the safe maximum. `setup()` mounts filesystems
-//! and can only be tested in ephemeral VMs.
 
 use crate::coreutils::{ln, mknod};
 use anyhow::{Context, Result};
-use nix::mount::{self, MsFlags};
+use nix::mount::MsFlags;
 use nix::sys::stat;
 use std::fs;
 use std::path::Path;
 
-/// Check if path is mounted (exact match on mountpoint, not substring).
-/// Uses exact field matching to avoid false positives like "/dev" matching "/dev/pts".
-/// Public for fuzzing: parses arbitrary /proc/mounts content.
-pub fn is_mounted_in(mounts: &str, path: &str) -> bool {
-    mounts
-        .lines()
-        .any(|line| line.split_whitespace().nth(1) == Some(path))
-}
-
-/// Check if a filesystem type is available in the kernel.
-/// Some filesystems (securityfs, efivarfs) may not be present in all kernels.
-fn fs_available_in(filesystems: &str, fs: &str) -> bool {
-    filesystems.lines().any(|line| line.contains(fs))
-}
-
-/// Mount filesystem only if not already mounted.
-/// Idempotent: safe to call multiple times. Uses pre-read mounts snapshot
-/// to avoid TOCTOU races between check and mount.
-fn mount_cached(
-    mounts: &str,
+/// Mount a filesystem. Errors if mount fails.
+fn mount(
     source: &str,
     target: &str,
     fstype: &str,
     flags: MsFlags,
     data: Option<&str>,
 ) -> Result<()> {
-    if !is_mounted_in(mounts, target) {
-        mount::mount(Some(source), target, Some(fstype), flags, data)
-            .with_context(|| format!("Failed to mount {source} on {target}"))?;
-    }
-    Ok(())
+    nix::mount::mount(Some(source), target, Some(fstype), flags, data)
+        .with_context(|| format!("mount {source} on {target}"))
 }
 
 /// Remount a filesystem as read-only.
@@ -51,24 +27,26 @@ fn mount_cached(
 /// reducing attack surface in the confidential VM.
 pub fn readonly(target: &str) -> Result<()> {
     let flags = MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_RDONLY | MsFlags::MS_REMOUNT;
-    mount::mount(None::<&str>, target, None::<&str>, flags, None::<&str>)
-        .with_context(|| format!("Failed to remount {target} readonly"))
+    nix::mount::mount(None::<&str>, target, None::<&str>, flags, None::<&str>)
+        .with_context(|| format!("remount {target} readonly"))
 }
 
-/// Mount filesystem only if the fstype is available AND the target exists.
-/// Used for optional filesystems like securityfs and efivarfs that may not
-/// be present on all systems or kernel configurations.
-fn mount_if_cached(
-    mounts: &str,
+/// Check if a filesystem type is available in the kernel.
+fn fs_available(filesystems: &str, fstype: &str) -> bool {
+    filesystems.lines().any(|line| line.contains(fstype))
+}
+
+/// Mount optional filesystem if the fstype is available AND the target exists.
+/// Used for securityfs and efivarfs that may not be present on all kernels.
+fn mount_optional(
     filesystems: &str,
-    fstype: &str,
     source: &str,
     target: &str,
+    fstype: &str,
     flags: MsFlags,
-    data: Option<&str>,
 ) -> Result<()> {
-    if fs_available_in(filesystems, fstype) && Path::new(target).exists() {
-        mount_cached(mounts, source, target, fstype, flags, data)?;
+    if fs_available(filesystems, fstype) && Path::new(target).exists() {
+        mount(source, target, fstype, flags, None)?;
     }
     Ok(())
 }
@@ -109,78 +87,55 @@ fn device_nodes(root: &str) -> Result<()> {
 
 /// Set up the minimal filesystem hierarchy required for GPU initialization.
 /// Creates /proc, /dev, /sys, /run, /tmp mounts and essential device nodes.
-/// Snapshot-based: reads mount state once to avoid TOCTOU races.
 pub fn setup() -> Result<()> {
     setup_at("")
 }
 
 /// Internal: setup with configurable root path (for testing with temp directories).
 fn setup_at(root: &str) -> Result<()> {
-    // Snapshot mount state once - consistent view, no TOCTOU
-    let mounts = fs::read_to_string("/proc/mounts").unwrap_or_default();
-    let filesystems = fs::read_to_string("/proc/filesystems").unwrap_or_default();
-
     let common = MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC | MsFlags::MS_NODEV | MsFlags::MS_RELATIME;
-    mount_cached(
-        &mounts,
-        "proc",
-        &format!("{root}/proc"),
-        "proc",
-        common,
-        None,
-    )?;
+
+    mount("proc", &format!("{root}/proc"), "proc", common, None)?;
+
     let dev_flags = MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC | MsFlags::MS_RELATIME;
-    mount_cached(
-        &mounts,
+    mount(
         "dev",
         &format!("{root}/dev"),
         "devtmpfs",
         dev_flags,
         Some("mode=0755"),
     )?;
-    mount_cached(
-        &mounts,
-        "sysfs",
-        &format!("{root}/sys"),
-        "sysfs",
-        common,
-        None,
-    )?;
-    mount_cached(
-        &mounts,
+
+    mount("sysfs", &format!("{root}/sys"), "sysfs", common, None)?;
+    mount(
         "run",
         &format!("{root}/run"),
         "tmpfs",
         common,
         Some("mode=0755"),
     )?;
+
     let tmp_flags = MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_RELATIME;
-    mount_cached(
-        &mounts,
-        "tmpfs",
-        &format!("{root}/tmp"),
-        "tmpfs",
-        tmp_flags,
-        None,
-    )?;
-    mount_if_cached(
-        &mounts,
+    mount("tmpfs", &format!("{root}/tmp"), "tmpfs", tmp_flags, None)?;
+
+    // Read once for all optional mounts
+    let filesystems = fs::read_to_string("/proc/filesystems").unwrap_or_default();
+
+    mount_optional(
         &filesystems,
-        "securityfs",
         "securityfs",
         &format!("{root}/sys/kernel/security"),
+        "securityfs",
         common,
-        None,
     )?;
-    mount_if_cached(
-        &mounts,
+    mount_optional(
         &filesystems,
         "efivarfs",
-        "efivarfs",
         &format!("{root}/sys/firmware/efi/efivars"),
+        "efivarfs",
         common,
-        None,
     )?;
+
     proc_symlinks(root)?;
     device_nodes(root)?;
     Ok(())
@@ -190,115 +145,45 @@ fn setup_at(root: &str) -> Result<()> {
 mod tests {
     use super::*;
     use crate::test_utils::require_root;
-    use std::fs;
 
-    // === Safe parsing function tests ===
-
-    #[test]
-    fn test_is_mounted_in() {
-        let mounts = fs::read_to_string("/proc/mounts").unwrap();
-        assert!(is_mounted_in(&mounts, "/"));
-        assert!(!is_mounted_in(&mounts, "/nonexistent"));
-    }
+    // === fs_available tests ===
 
     #[test]
-    fn test_is_mounted_exact_match() {
-        // /dev/pts mounted should NOT match /dev (substring matching bug fix)
-        let mounts = "devpts /dev/pts devpts rw 0 0\ntmpfs /tmp tmpfs rw 0 0\n";
-        assert!(!is_mounted_in(mounts, "/dev"));
-        assert!(is_mounted_in(mounts, "/dev/pts"));
-        assert!(is_mounted_in(mounts, "/tmp"));
-    }
-
-    #[test]
-    fn test_is_mounted_empty() {
-        assert!(!is_mounted_in("", "/"));
-        assert!(!is_mounted_in("", "/dev"));
-    }
-
-    #[test]
-    fn test_fs_available_in() {
+    fn test_fs_available() {
         let filesystems = fs::read_to_string("/proc/filesystems").unwrap();
-        assert!(fs_available_in(&filesystems, "proc"));
-        assert!(fs_available_in(&filesystems, "sysfs"));
-        assert!(!fs_available_in(&filesystems, "nonexistent_fs"));
+        assert!(fs_available(&filesystems, "proc"));
+        assert!(fs_available(&filesystems, "sysfs"));
+        assert!(fs_available(&filesystems, "tmpfs"));
+        assert!(!fs_available(&filesystems, "nonexistent_fs"));
     }
 
     #[test]
     fn test_fs_available_empty() {
-        assert!(!fs_available_in("", "proc"));
+        assert!(!fs_available("", "proc"));
+        assert!(!fs_available("", "tmpfs"));
     }
 
-    // === mount_cached tests (safe: no-op when already mounted) ===
+    // === mount_optional tests ===
 
     #[test]
-    fn test_mount_cached_already_mounted() {
-        // When target is already in mounts, mount_cached is a no-op
-        let mounts = "proc /proc proc rw 0 0\n";
-        let result = mount_cached(mounts, "proc", "/proc", "proc", MsFlags::empty(), None);
-        assert!(result.is_ok());
-    }
-
-    // === mount_if_cached tests (safe: no-op when conditions not met) ===
-
-    #[test]
-    fn test_mount_if_cached_fs_not_available() {
-        // When filesystem is not available, should be no-op
-        let mounts = "";
-        let filesystems = "nodev tmpfs\n";
-        let result = mount_if_cached(
-            mounts,
-            filesystems,
-            "nonexistent_fs",
-            "src",
-            "/tmp", // exists but fs not available
-            MsFlags::empty(),
-            None,
-        );
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_mount_if_cached_target_not_exists() {
+    fn test_mount_optional_target_not_exists() {
         // When target path doesn't exist, should be no-op
-        let mounts = "";
         let filesystems = "nodev tmpfs\n";
-        let result = mount_if_cached(
-            mounts,
+        let result = mount_optional(
             filesystems,
             "tmpfs",
-            "src",
             "/nonexistent/path",
+            "tmpfs",
             MsFlags::empty(),
-            None,
         );
         assert!(result.is_ok());
     }
 
-    #[test]
-    fn test_mount_if_cached_already_mounted() {
-        // When already mounted, should be no-op
-        let mounts = "tmpfs /tmp tmpfs rw 0 0\n";
-        let filesystems = "nodev tmpfs\n";
-        let result = mount_if_cached(
-            mounts,
-            filesystems,
-            "tmpfs",
-            "tmpfs",
-            "/tmp",
-            MsFlags::empty(),
-            None,
-        );
-        assert!(result.is_ok());
-    }
-
-    // === Error path tests (safe: mount fails, no changes made) ===
+    // === Error path tests ===
 
     #[test]
-    fn test_mount_cached_fails_nonexistent_target() {
-        let mounts = "";
-        let err = mount_cached(
-            mounts,
+    fn test_mount_fails_nonexistent_target() {
+        let err = mount(
             "tmpfs",
             "/nonexistent/mount/point",
             "tmpfs",
@@ -306,7 +191,6 @@ mod tests {
             None,
         )
         .unwrap_err();
-        // Should contain the mount target in error context
         assert!(
             err.to_string().contains("/nonexistent/mount/point"),
             "error should mention the path: {}",
@@ -317,7 +201,6 @@ mod tests {
     #[test]
     fn test_readonly_fails_nonexistent() {
         let err = readonly("/nonexistent/path").unwrap_err();
-        // Should contain the path in error context
         assert!(
             err.to_string().contains("/nonexistent/path"),
             "error should mention the path: {}",
@@ -363,11 +246,6 @@ mod tests {
         // Run setup_at with temp root
         let result = setup_at(root);
         assert!(result.is_ok(), "setup_at failed: {:?}", result);
-
-        // Verify mounts happened
-        let mounts = fs::read_to_string("/proc/mounts").unwrap();
-        assert!(is_mounted_in(&mounts, &format!("{root}/run")));
-        assert!(is_mounted_in(&mounts, &format!("{root}/tmp")));
 
         // Verify device nodes were created
         assert!(Path::new(&format!("{root}/dev/null")).exists());


### PR DESCRIPTION
We should fail if a mount already exists. This is not expected. Especially in the CC case we want to have full control of the VM.