### PR TITLE
fix(kata-agent): use syslog::try_poll in drain loop to avoid kata 255

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,8 +52,14 @@ jobs:
 
           grep kernel_params /etc/kata-containers/configuration.toml
 
-          output=$(sudo nerdctl run --runtime io.containerd.kata.v2 --device /dev/vfio/devices/vfio0 --rm ubuntu -- sh -c "nvidia-smi; dmesg" 2>&1 || true)
+          output=$(sudo nerdctl run --runtime io.containerd.kata.v2 --device /dev/vfio/devices/vfio0 --rm ubuntu -- sh -c "nvidia-smi; dmesg" 2>&1)
+          exit_code=$?
           echo "$output"
+
+          if [ "$exit_code" != "0" ]; then
+            echo "FAILED: nerdctl exited with $exit_code (expected 0)"
+            exit 1
+          fi
 
           echo "$output" | grep -q "NVIDIA-SMI" || exit 1
 
@@ -70,8 +76,14 @@ jobs:
 
           grep kernel_params /etc/kata-containers/configuration.toml
 
-          output=$(sudo nerdctl run --runtime io.containerd.kata.v2 --device /dev/vfio/devices/vfio0 --rm ubuntu -- sh -c "nvidia-smi; dmesg" 2>&1 || true)
+          output=$(sudo nerdctl run --runtime io.containerd.kata.v2 --device /dev/vfio/devices/vfio0 --rm ubuntu -- sh -c "nvidia-smi; dmesg" 2>&1)
+          exit_code=$?
           echo "$output"
+
+          if [ "$exit_code" != "0" ]; then
+            echo "FAILED: nerdctl exited with $exit_code (expected 0)"
+            exit 1
+          fi
 
           echo "$output" | grep -q "NVIDIA-SMI" || exit 1
 

--- a/src/kata_agent.rs
+++ b/src/kata_agent.rs
@@ -47,13 +47,16 @@ fn kata_agent(path: &str) {
     exec_agent(path);
 }
 
-/// Guest VMs lack a syslog daemon, so we poll /dev/log to drain messages
-/// and forward them to kmsg. Timeout enables testing without infinite loops.
+/// Drains `/dev/log` (bound in `main()` before fork) into `/run/syslog.log`.
+///
+/// Uses `try_poll()` not `poll()`: this child inherits NVRC's power-off panic
+/// hook, and a transient drain I/O error must not reboot the VM while
+/// kata-agent is still running (kata exit 255).
 fn syslog_loop(timeout_secs: u32) {
     let iterations = (timeout_secs as u64) * 2; // 500ms per iteration
     for _ in 0..iterations {
         sleep(Duration::from_millis(500));
-        crate::syslog::poll();
+        crate::syslog::try_poll();
     }
 }
 
@@ -64,7 +67,7 @@ pub fn fork_agent(timeout_secs: u32) {
     // SAFETY: fork() is safe here because:
     // 1. We are PID 1 with no other threads (single-threaded process)
     // 2. Parent immediately execs kata-agent (no shared state issues)
-    // 3. Child only calls async-signal-safe functions (syslog::poll, sleep)
+    // 3. Child only calls async-signal-safe functions (syslog::try_poll, sleep)
     // 4. No locks or mutexes exist that could deadlock in child
     match unsafe { fork() }.expect("fork agent") {
         ForkResult::Parent { .. } => {
@@ -81,6 +84,7 @@ mod tests {
     use super::*;
     use crate::test_utils::require_root;
     use nix::sys::wait::{waitpid, WaitStatus};
+    use serial_test::serial;
     use std::panic;
 
     /// Install a panic hook that exits with code 1.
@@ -143,19 +147,61 @@ mod tests {
 
     #[test]
     fn test_syslog_loop_timeout() {
-        // syslog_loop with 1 second timeout runs up to 2 iterations (500ms each).
-        // Two possible outcomes:
-        // 1. poll() works: runs full 2 iterations (~1000ms)
-        // 2. poll() panics: test fails due to missing /dev/log
-        // We catch_unwind to handle missing /dev/log gracefully in test env
+        // ~1s: two 500ms iterations; try_poll() is best-effort on /dev/log.
         let start = std::time::Instant::now();
-        let _ = panic::catch_unwind(|| syslog_loop(1));
+        syslog_loop(1);
         let elapsed = start.elapsed();
 
         // Lower bound: at least 1 sleep cycle (500ms) runs before poll
         // Upper bound: 2 iterations + scheduling overhead = ~1200ms max
         assert!(elapsed.as_millis() >= 400);
         assert!(elapsed.as_millis() < 1500);
+    }
+
+    /// Regression: with the power-off hook installed, syslog_loop must not panic
+    /// on drain I/O (fork isolates from parallel tests). In-VM, `/dev/log` is
+    /// already bound by main(); this child does a fresh bind — on dev hosts
+    /// with a host syslog daemon, reverting to `poll()` reproduces via EADDRINUSE.
+    #[test]
+    #[serial]
+    fn test_syslog_loop_does_not_trigger_power_off_hook() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let saved_hook = panic::take_hook();
+
+        let triggered = Arc::new(AtomicBool::new(false));
+        let triggered_for_hook = triggered.clone();
+
+        crate::lockdown::set_panic_hook_with(move || {
+            triggered_for_hook.store(true, Ordering::SeqCst);
+        });
+
+        // SAFETY: child runs syslog_loop and exits; no shared state.
+        let fork_result = unsafe { fork() }.expect("fork");
+
+        match fork_result {
+            ForkResult::Parent { child } => {
+                let status = waitpid(child, None).expect("waitpid");
+                panic::set_hook(saved_hook);
+
+                assert_eq!(
+                    status,
+                    WaitStatus::Exited(child, 0),
+                    "syslog_loop must not fire the power-off hook on drain I/O \
+                     (kata exit 255 regression)"
+                );
+            }
+            ForkResult::Child => {
+                let loop_result = panic::catch_unwind(|| syslog_loop(1));
+
+                if triggered.load(Ordering::SeqCst) || loop_result.is_err() {
+                    std::process::exit(42);
+                } else {
+                    std::process::exit(0);
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/lockdown.rs
+++ b/src/lockdown.rs
@@ -28,7 +28,7 @@ pub fn set_panic_hook() {
 
 /// Internal: panic handler with configurable shutdown (for unit tests).
 /// Production uses power_off(); tests inject a no-op to avoid rebooting.
-fn set_panic_hook_with<F: Fn() + Send + Sync + 'static>(shutdown: F) {
+pub(crate) fn set_panic_hook_with<F: Fn() + Send + Sync + 'static>(shutdown: F) {
     panic::set_hook(Box::new(move |panic_info| {
         // fd 1,2 are always available from the kernel
         eprintln!("panic: {panic_info}");


### PR DESCRIPTION
NVRC's syslog_loop runs in the syslog poller child of fork_agent for
~136 years, draining /dev/log every 500ms. NVRC's power-off panic hook
(installed in main() before the fork) is inherited by the child — by
design: a real NVRC failure in there must still tear down the VM, per
the ephemeral confidential-VM fail-hard policy.

Guest VMs have no syslog daemon: main() binds /dev/log via
syslog::poll() before fork_agent, and the syslog child inherits that
socket. A transient drain I/O error during the long-running loop —
EBADF on recv, ENOSPC on append to /run/syslog.log, etc. — is NOT a
configuration failure and NOT VM-fatal. Yet syslog::poll() (or_panic on
any error) made every such hiccup panic the syslog child, fire the
inherited power-off hook, and reboot the VM while kata-agent (now PID 1)
was still serving the workload. kata-runtime would then observe a dead
agent and return exit code 255 to docker/nerdctl, masking the workload's
real exit code. This is the bug behind the '|| true' masks that had been
added to .github/workflows/ci.yaml around the nerdctl invocations.

Fix: syslog_loop now calls syslog::try_poll() (best-effort, silently
swallows transient I/O errors — already provided for exactly this case)
instead of syslog::poll(). The fail-hard panic hook stays in place for
every other code path; only the auxiliary syslog drain is demoted from
VM-fatal to best-effort.

Add test_syslog_loop_does_not_trigger_power_off_hook as a regression
guard: fork to isolate the production-shape panic hook from parallel
tests, run a short syslog_loop in the child, and assert the hook never
fired (exit 0). The test child does a fresh bind (unlike production,
where main() already bound /dev/log); on dev hosts where a host syslog
daemon owns /dev/log, reverting to syslog::poll() reproduces the bug
via EADDRINUSE — a local reproducer, not the in-VM failure mode.

Drop the '|| true' workarounds in .github/workflows/ci.yaml that were
masking the bug; replace them with explicit exit-code checks now that
exit codes propagate honestly. Bump lockdown::set_panic_hook_with to
pub(crate) so the regression test can install the production-shape hook
(its doc comment already advertised it as "for unit tests").