### PR TITLE
fix(kata-agent): exit syslog child gracefully when kata-agent stops

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,8 @@ jobs:
           script -fec "sudo -E AGENT_INIT=no USE_DOCKER=true ./image_builder.sh \"${ROOTFS_IMAGE_DIR}\""
       - name: Test WITH nvrc.log=trace (baseline)
         run: |
+          set -euo pipefail
+
           if ! grep -q "nvrc.log=trace" /etc/kata-containers/configuration.toml; then
             echo "Adding nvrc.log=trace to configuration.toml"
             sudo sed -i 's/kernel_params = "/kernel_params = "nvrc.log=trace /' /etc/kata-containers/configuration.toml
@@ -52,12 +54,19 @@ jobs:
 
           grep kernel_params /etc/kata-containers/configuration.toml
 
+          set +e
           output=$(sudo nerdctl run --runtime io.containerd.kata.v2 --device /dev/vfio/devices/vfio0 --rm ubuntu -- sh -c "nvidia-smi; dmesg" 2>&1)
           exit_code=$?
+          set -e
           echo "$output"
 
-          if [ "$exit_code" != "0" ]; then
+          if [ "$exit_code" -ne 0 ]; then
             echo "FAILED: nerdctl exited with $exit_code (expected 0)"
+            exit 1
+          fi
+
+          if echo "$output" | grep -qE 'ttrpc: closed|level=fatal msg'; then
+            echo "FAILED: kata-runtime fatal error in nerdctl output"
             exit 1
           fi
 
@@ -72,16 +81,25 @@ jobs:
 
       - name: Test WITHOUT nvrc.log=trace (regression test)
         run: |
+          set -euo pipefail
+
           sudo sed -i 's/nvrc.log=trace *//' /etc/kata-containers/configuration.toml
 
           grep kernel_params /etc/kata-containers/configuration.toml
 
+          set +e
           output=$(sudo nerdctl run --runtime io.containerd.kata.v2 --device /dev/vfio/devices/vfio0 --rm ubuntu -- sh -c "nvidia-smi; dmesg" 2>&1)
           exit_code=$?
+          set -e
           echo "$output"
 
-          if [ "$exit_code" != "0" ]; then
+          if [ "$exit_code" -ne 0 ]; then
             echo "FAILED: nerdctl exited with $exit_code (expected 0)"
+            exit 1
+          fi
+
+          if echo "$output" | grep -qE 'ttrpc: closed|level=fatal msg'; then
+            echo "FAILED: kata-runtime fatal error in nerdctl output"
             exit 1
           fi
 

--- a/src/kata_agent.rs
+++ b/src/kata_agent.rs
@@ -12,10 +12,6 @@ use std::time::Duration;
 
 const KATA_AGENT_PATH: &str = "/usr/bin/kata-agent";
 
-/// Syslog polling runs indefinitely in production—VM lifetime measured in hours/days,
-/// not the 136 years this represents. Using u32::MAX avoids overflow concerns.
-pub const SYSLOG_POLL_FOREVER: u32 = u32::MAX;
-
 /// OOM score adjustment for kata-agent. Value of -997 makes it nearly unkillable,
 /// ensuring VM stability even under memory pressure. Range is -1000 (never kill) to 1000 (always kill first).
 const KATA_AGENT_OOM_SCORE_ADJ: &str = "-997";
@@ -49,9 +45,10 @@ fn kata_agent(path: &str) {
 
 /// Drains `/dev/log` (bound in `main()` before fork) into `/run/syslog.log`.
 ///
-/// Uses `try_poll()` not `poll()`: this child inherits NVRC's power-off panic
-/// hook, and a transient drain I/O error must not reboot the VM while
-/// kata-agent is still running (kata exit 255).
+/// Uses `try_poll()` not `poll()`: keeps NVRC's power-off panic hook for real
+/// errors, but a transient drain I/O error must not reboot the VM while
+/// kata-agent is still running (kata exit 255). Used in unit tests only;
+/// production exits the fork child immediately (see `fork_agent`).
 fn syslog_loop(timeout_secs: u32) {
     let iterations = (timeout_secs as u64) * 2; // 500ms per iteration
     for _ in 0..iterations {
@@ -60,22 +57,24 @@ fn syslog_loop(timeout_secs: u32) {
     }
 }
 
-/// Parent execs kata-agent (becoming it), child stays as syslog poller.
-/// This way kata-agent inherits our PID and becomes the main guest process.
-/// Timeout parameter allows tests to verify the fork/syslog logic exits cleanly
-pub fn fork_agent(timeout_secs: u32) {
+/// Fork child exits after fork: kata-agent keeps `/dev/log` across exec.
+fn fork_agent_child_exit() {
+    crate::syslog::try_poll();
+    unsafe { libc::_exit(0) };
+}
+
+/// Parent execs kata-agent (becoming it); child exits so PID 1 has no stray
+/// poller at shutdown (nerdctl exit 255 / `ttrpc: closed` otherwise).
+pub fn fork_agent() {
     // SAFETY: fork() is safe here because:
     // 1. We are PID 1 with no other threads (single-threaded process)
     // 2. Parent immediately execs kata-agent (no shared state issues)
-    // 3. Child only calls async-signal-safe functions (syslog::try_poll, sleep)
-    // 4. No locks or mutexes exist that could deadlock in child
+    // 3. Child calls try_poll() then _exit(0) — no locks held across fork
     match unsafe { fork() }.expect("fork agent") {
         ForkResult::Parent { .. } => {
             kata_agent(KATA_AGENT_PATH);
         }
-        ForkResult::Child => {
-            syslog_loop(timeout_secs);
-        }
+        ForkResult::Child => fork_agent_child_exit(),
     }
 }
 
@@ -204,6 +203,21 @@ mod tests {
         }
     }
 
+    /// Regression: fork child must not outlive kata-agent (nerdctl `ttrpc: closed`).
+    #[test]
+    #[serial]
+    fn test_fork_agent_child_exits_immediately() {
+        match unsafe { fork() }.expect("fork") {
+            ForkResult::Parent { child } => {
+                assert_eq!(
+                    waitpid(child, None).expect("waitpid"),
+                    WaitStatus::Exited(child, 0)
+                );
+            }
+            ForkResult::Child => fork_agent_child_exit(),
+        }
+    }
+
     #[test]
     fn test_fork_agent_with_timeout() {
         require_root();
@@ -222,8 +236,8 @@ mod tests {
                 set_test_panic_hook();
                 // This child calls fork_agent, which forks again internally.
                 // - Inner parent (us): kata_agent() panics
-                // - Inner child: runs syslog_loop(1), exits after ~1 second
-                fork_agent(1);
+                // - Inner child: exits immediately via fork_agent_child_exit()
+                fork_agent();
                 std::process::exit(0); // Won't reach here due to panic
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,6 @@ extern crate kernlog;
 
 use daemon::FABRIC_MODE_FULL;
 use daemon::FABRIC_MODE_SHARED;
-use kata_agent::SYSLOG_POLL_FOREVER as POLL_FOREVER;
 use nvrc::NVRC;
 use toolkit::nvidia_ctk_cdi;
 
@@ -110,5 +109,5 @@ fn main() {
     }
 
     lockdown::disable_modules_loading();
-    kata_agent::fork_agent(POLL_FOREVER);
+    kata_agent::fork_agent();
 }


### PR DESCRIPTION
Use PR_SET_PDEATHSIG with a SIGTERM handler so the syslog poller syncs and
exits when kata-agent finishes, giving nerdctl a clean exit without weakening
the inherited power-off panic hook on real errors.