### PR TITLE
hash: log version and sha256 of /proc/self/exe at boot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,9 @@ jobs:
           targets: aarch64-unknown-linux-musl
       - name: Build NVRC
         run: |
+          GIT_REV="$(git rev-parse --short HEAD)"
+          if [ -n "$(git status --porcelain)" ]; then GIT_REV="${GIT_REV}-dirty"; fi
+          export GIT_REV
           cargo build --release --target=aarch64-unknown-linux-musl
           sudo cp ./target/aarch64-unknown-linux-musl/release/NVRC "$ROOTFS_IMAGE_DIR/bin/NVRC-aarch64-unknown-linux-musl"
       - name: Create Image with NVRC

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ env:
   ROOTFS_IMAGE_DIR: /home/ubuntu/actions-runner/_work/kata-containers/build/rootfs-image-nvidia-gpu/builddir/rootfs-image/ubuntu_rootfs
   IMAGE_BUILDER_DIR: /home/ubuntu/actions-runner/_work/kata-containers/tools/osbuilder/image-builder
 jobs:
-  build-asset:
+  run-e2e-nerdctl-tests:
     runs-on: g5g.metal
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,9 @@ processes, and sockets.
 5. **Minimize Rust Crates**: Suggest smaller crates rather then  pulling in huge
    crates like nix
 6. **KISS**: Minimize the cyclomatic complexity, keep code simple and stupid
+7. **Self-describing code**: Names carry the WHAT so comments can focus on the
+   WHY. If you reach for a comment to explain what a function, type, or
+   variable does, rename it instead. Reserve comments for non-obvious WHY:
+   hidden constraints, subtle invariants, source citations for magic constants
+   (e.g. NIST test vectors), or workarounds for specific bugs. Don't restate
+   what well-named code already says.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "once_cell",
  "rlimit",
  "serial_test",
+ "sha2",
  "tempfile",
 ]
 
@@ -31,6 +32,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +51,35 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "errno"
@@ -133,6 +172,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -360,6 +409,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +459,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +478,12 @@ checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom 0.2.15",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ kernlog = "0.3"
 rlimit = "0.10.2"
 libc = "0.2.178"
 once_cell = "1.21.3"
+sha2 = { version = "0.10", default-features = false }
 
 [profile.release]
 opt-level = "s"

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -21,9 +21,29 @@ use std::fs;
 const SELF_EXE: &str = "/proc/self/exe";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+// Untrusted dev-convenience stamp: the short commit the binary was built from,
+// plus `-dirty` for an uncommitted tree, set by CI on the build command. Lets a
+// dmesg glance tell a dirty/local build from a clean release; absent on a plain
+// release build, which logs VERSION alone. A tampered binary can forge this —
+// authoritative release identity is the sha256 vs Rekor (see above and
+// ARCHITECTURE.md).
+const GIT_REV: Option<&str> = option_env!("GIT_REV");
+
 pub fn self_exe() {
+    debug!("{}", version_line());
+}
+
+pub fn version_line() -> String {
     let digest = sha256().or_panic(format_args!("hash {SELF_EXE}"));
-    debug!("NVRC version={VERSION} sha256={digest}");
+    boot_line(&digest, GIT_REV)
+}
+
+fn boot_line(digest: &str, rev: Option<&str>) -> String {
+    format!("NVRC version={} sha256={digest}", version(rev))
+}
+
+fn version(rev: Option<&str>) -> String {
+    rev.map_or_else(|| VERSION.to_string(), |rev| format!("{VERSION}+{rev}"))
 }
 
 fn sha256() -> std::io::Result<String> {
@@ -81,5 +101,55 @@ mod tests {
     #[test]
     fn test_self_exe_runs_to_completion() {
         self_exe();
+    }
+
+    #[test]
+    fn test_version_without_rev_is_bare_cargo_version() {
+        assert_eq!(version(None), VERSION);
+    }
+
+    #[test]
+    fn test_version_with_rev_appends_plus_metadata() {
+        assert_eq!(version(Some("4895486")), format!("{VERSION}+4895486"));
+    }
+
+    #[test]
+    fn test_version_with_dirty_rev_preserves_dirty_suffix() {
+        assert_eq!(
+            version(Some("4895486-dirty")),
+            format!("{VERSION}+4895486-dirty")
+        );
+    }
+
+    #[test]
+    fn test_boot_line_of_self_carries_cargo_version_and_real_digest() {
+        let digest = sha256().expect("hash self");
+        let line = boot_line(&digest, GIT_REV);
+
+        assert!(line.starts_with(&format!("NVRC version={}", env!("CARGO_PKG_VERSION"))));
+        assert!(line.ends_with(&format!("sha256={digest}")));
+        assert_eq!(
+            line,
+            format!("NVRC version={} sha256={digest}", version(GIT_REV))
+        );
+    }
+
+    #[test]
+    fn test_boot_line_release_build_logs_bare_version() {
+        assert_eq!(
+            boot_line("deadbeef", None),
+            format!("NVRC version={} sha256=deadbeef", env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    #[test]
+    fn test_boot_line_dev_build_appends_git_rev() {
+        assert_eq!(
+            boot_line("deadbeef", Some("4895486-dirty")),
+            format!(
+                "NVRC version={}+4895486-dirty sha256=deadbeef",
+                env!("CARGO_PKG_VERSION")
+            )
+        );
     }
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -30,7 +30,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const GIT_REV: Option<&str> = option_env!("GIT_REV");
 
 pub fn self_exe() {
-    debug!("{}", version_line());
+    info!("{}", version_line());
 }
 
 pub fn version_line() -> String {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) NVIDIA CORPORATION
+
+//! Lets operators correlate dmesg output against the cosign/Rekor digest
+//! published in the release evidence bundle, so a running NVRC can be matched
+//! to its release artifact independently of the build pipeline (see
+//! ARCHITECTURE.md §"Provenance & Supply-Chain Security").
+//!
+//! Not a security primitive: binary integrity is already enforced before
+//! `execve` by dm-verity (block layer), fs-verity (file layer), and IPE
+//! (see ARCHITECTURE.md §"Measured Rootfs" and §"Integrity Policy
+//! Enforcement"). A compromised NVRC could lie about its own hash — the
+//! trustworthy digest is the one in Rekor, not the one in dmesg.
+
+use crate::macros::ResultExt;
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use std::fs;
+
+// TODO(hardened_std): add to fs path whitelist when hardened_std::fs lands
+const SELF_EXE: &str = "/proc/self/exe";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub fn self_exe() {
+    let digest = sha256().or_panic(format_args!("hash {SELF_EXE}"));
+    debug!("NVRC version={VERSION} sha256={digest}");
+}
+
+fn sha256() -> std::io::Result<String> {
+    fs::read(SELF_EXE).map(|data| hex_encode(&Sha256::digest(&data)))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut s, b| {
+            let _ = write!(s, "{b:02x}");
+            s
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hex_encode_empty() {
+        assert_eq!(hex_encode(&[]), "");
+    }
+
+    #[test]
+    fn test_hex_encode_known_vector() {
+        assert_eq!(hex_encode(&[0x00, 0xff, 0xab, 0x12, 0x9c]), "00ffab129c");
+    }
+
+    #[test]
+    fn test_sha256_self_returns_64_hex_chars() {
+        let digest = sha256().expect("hash self");
+        assert_eq!(digest.len(), 64);
+        assert!(digest.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_sha256_empty_string_known_vector() {
+        // NIST: SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        assert_eq!(
+            hex_encode(&Sha256::digest(b"")),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn test_sha256_abc_known_vector() {
+        // NIST: SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        assert_eq!(
+            hex_encode(&Sha256::digest(b"abc")),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn test_self_exe_runs_to_completion() {
+        self_exe();
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) NVIDIA CORPORATION
+
+use crate::hash;
+
+/// NVRC's init duties (mounts, module loads, daemon forks, the poweroff panic
+/// hook) would wreck a normal host, so they must only run as PID 1. Anywhere
+/// else (CI smoke test, dev shell) report identity and exit before the caller
+/// touches anything.
+pub fn as_pid1() {
+    as_pid1_with(running_as_init(), || std::process::exit(0));
+}
+
+// Production exits the process; tests inject a no-op to observe the bail path
+// without killing the runner (cf. lockdown::set_panic_hook_with).
+fn as_pid1_with<F: FnOnce()>(is_init: bool, exit: F) {
+    if is_init {
+        return;
+    }
+    // No logger on this path, so print to stdout rather than via the dropped
+    // log macros; this is the CI smoke test's only observable output.
+    println!("{}", hash::version_line());
+    exit();
+}
+
+// Raw SYS_getpid syscall: stays on the pure-syscall path hardened_std targets,
+// and needs no /proc (unmounted this early, mount::setup runs later).
+fn running_as_init() -> bool {
+    unsafe { libc::syscall(libc::SYS_getpid) == 1 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    #[test]
+    fn test_running_as_init_false_for_test_harness() {
+        // The test runner is never PID 1, so the real syscall must report so.
+        assert!(!running_as_init());
+    }
+
+    #[test]
+    fn test_as_pid1_returns_without_exiting_when_init() {
+        let exited = Cell::new(false);
+        as_pid1_with(true, || exited.set(true));
+        assert!(
+            !exited.get(),
+            "must fall through to the caller's init sequence"
+        );
+    }
+
+    #[test]
+    fn test_as_pid1_exits_when_not_init() {
+        let exited = Cell::new(false);
+        as_pid1_with(false, || exited.set(true));
+        assert!(exited.get(), "non-PID-1 must report identity and exit");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod config;
 pub mod daemon;
 pub mod execute;
+pub mod hash;
 pub mod kata_agent;
 pub mod kernel_params;
 pub mod kmsg;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 mod config;
 mod daemon;
 mod execute;
+mod hash;
 mod infiniband;
 mod kata_agent;
 mod kernel_params;
@@ -99,6 +100,7 @@ fn main() {
     kmsg::kernlog_setup();
     syslog::poll();
     init.process_kernel_params(None);
+    hash::self_exe();
 
     let detected = mode::detect();
     match detected.mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod daemon;
 mod execute;
 mod hash;
 mod infiniband;
+mod init;
 mod kata_agent;
 mod kernel_params;
 mod kmsg;
@@ -93,6 +94,8 @@ fn mode_nvl5(init: &mut NVRC, fabric_mode: u8) {
 }
 
 fn main() {
+    init::as_pid1();
+
     lockdown::set_panic_hook();
     let mut init = NVRC::default();
     mount::setup();


### PR DESCRIPTION
Enables operators to correlate dmesg output against the cosign/Rekor digest published in the release evidence bundle (ARCHITECTURE.md §"Provenance & Supply-Chain Security").

Also, an indicator for CI runs to verify we're indeed running the new binary. 