### PR TITLE
ci: re-add nerdctl exit-code tolerance until kata fix lands

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,17 +95,17 @@ jobs:
             echo "WARNING: nerdctl exited with $exit_code (expected 0); ignoring pending kata-containers fix"
           fi
 
-          if echo "$output" | grep -qE 'ttrpc: closed|level=fatal'; then
+          if grep -qE 'ttrpc: closed|level=fatal' <<<"$output"; then
             echo "WARNING: kata-runtime fatal error in nerdctl output (ignoring pending kata-containers fix):"
-            echo "$output" | grep -E 'ttrpc: closed|level=fatal'
+            grep -E 'ttrpc: closed|level=fatal' <<<"$output"
           fi
 
-          if ! echo "$output" | grep -q "NVIDIA-SMI"; then
+          if ! grep -q "NVIDIA-SMI" <<<"$output"; then
             echo "ERROR: nvidia-smi did not produce expected NVIDIA-SMI banner"
             exit 1
           fi
 
-          if ! echo "$output" | grep -q "NVRC"; then
+          if ! grep -q "NVRC" <<<"$output"; then
             echo "ERROR: nvrc.log=trace set but no NVRC logs in VM dmesg"
             exit 1
           fi
@@ -134,17 +134,17 @@ jobs:
             echo "WARNING: nerdctl exited with $exit_code (expected 0); ignoring pending kata-containers fix"
           fi
 
-          if echo "$output" | grep -qE 'ttrpc: closed|level=fatal'; then
+          if grep -qE 'ttrpc: closed|level=fatal' <<<"$output"; then
             echo "WARNING: kata-runtime fatal error in nerdctl output (ignoring pending kata-containers fix):"
-            echo "$output" | grep -E 'ttrpc: closed|level=fatal'
+            grep -E 'ttrpc: closed|level=fatal' <<<"$output"
           fi
 
-          if ! echo "$output" | grep -q "NVIDIA-SMI"; then
+          if ! grep -q "NVIDIA-SMI" <<<"$output"; then
             echo "ERROR: nvidia-smi did not produce expected NVIDIA-SMI banner"
             exit 1
           fi
 
-          if echo "$output" | grep -q "NVRC"; then
+          if grep -q "NVRC" <<<"$output"; then
             echo "ERROR: Found NVRC logs without nvrc.log=trace!"
             exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,15 +90,14 @@ jobs:
           echo "$output"
           echo "=== nerdctl exit code: $exit_code ==="
 
+          # TODO: non-fatal until kata-containers stops returning 255 on VM teardown.
           if [ "$exit_code" -ne 0 ]; then
-            echo "FAILED: nerdctl exited with $exit_code (expected 0)"
-            exit 1
+            echo "WARNING: nerdctl exited with $exit_code (expected 0); ignoring pending kata-containers fix"
           fi
 
           if echo "$output" | grep -qE 'ttrpc: closed|level=fatal'; then
-            echo "FAILED: kata-runtime fatal error in nerdctl output:"
+            echo "WARNING: kata-runtime fatal error in nerdctl output (ignoring pending kata-containers fix):"
             echo "$output" | grep -E 'ttrpc: closed|level=fatal'
-            exit 1
           fi
 
           if ! echo "$output" | grep -q "NVIDIA-SMI"; then
@@ -130,15 +129,14 @@ jobs:
           echo "$output"
           echo "=== nerdctl exit code: $exit_code ==="
 
+          # TODO: non-fatal until kata-containers stops returning 255 on VM teardown.
           if [ "$exit_code" -ne 0 ]; then
-            echo "FAILED: nerdctl exited with $exit_code (expected 0)"
-            exit 1
+            echo "WARNING: nerdctl exited with $exit_code (expected 0); ignoring pending kata-containers fix"
           fi
 
           if echo "$output" | grep -qE 'ttrpc: closed|level=fatal'; then
-            echo "FAILED: kata-runtime fatal error in nerdctl output:"
+            echo "WARNING: kata-runtime fatal error in nerdctl output (ignoring pending kata-containers fix):"
             echo "$output" | grep -E 'ttrpc: closed|level=fatal'
-            exit 1
           fi
 
           if ! echo "$output" | grep -q "NVIDIA-SMI"; then


### PR DESCRIPTION
Commit 04b8be5 removed the '|| true' masks around the E2E nerdctl invocations on the assumption that exit codes would propagate honestly after the NVRC syslog::try_poll fix. That was premature: kata-containers still returns 255 (and may emit 'ttrpc: closed'/'level=fatal') when the agent tears the VM down after the workload completes, which requires a fix on the kata-containers side first.

Demote the nerdctl exit-code check and the kata fatal-error grep from hard failures back to non-fatal warnings, keeping the diagnostics. The output-content checks (NVIDIA-SMI banner, NVRC log presence/absence) still gate the steps. Re-enable the hard failures once the kata-containers fix lands.