### PR TITLE
ci: Do not use pull_request_target

### DIFF
--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -1,13 +1,18 @@
 name: NVRC E2E
 on:
-  pull_request_target:
+  # Use pull_request (not pull_request_target) so the workflow definition is
+  # taken from the PR itself. This lets us validate changes to these YAML files
+  # in the PR instead of only discovering breakage after merge. The 'ok-to-test'
+  # label gate below is what protects the self-hosted runner; pull_request also
+  # runs fork PRs with a read-only token and no secrets, which is safer.
+  pull_request:
     branches:
       - 'main'
     types:
       # Adding 'labeled' to the list of activity types that trigger this event
       # (default: opened, synchronize, reopened) so that we can run this
       # workflow when the 'ok-to-test' label is added.
-      # Reference: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+      # Reference: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
       - opened
       - synchronize
       - reopened
@@ -32,14 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # For pull_request_target, checkout the PR head to detect changes
+          # Check out the PR head (not the merge commit) to detect changes
           ref: ${{ github.event.pull_request.head.sha }}
           # Fetch enough history to compare with base
           fetch-depth: 0
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
-          # For pull_request_target, explicitly specify base and ref
+          # Explicitly specify base and ref to compare PR head against base
           base: ${{ github.event.pull_request.base.sha }}
           ref: ${{ github.event.pull_request.head.sha }}
           filters: |

--- a/.github/workflows/revoke-ok-to-test.yaml
+++ b/.github/workflows/revoke-ok-to-test.yaml
@@ -1,0 +1,45 @@
+name: Revoke ok-to-test on push
+
+# Binds the 'ok-to-test' approval to a specific revision. When new commits are
+# pushed to a PR (synchronize), the label is removed so the E2E workflow
+# (ci-on-push.yaml) no longer runs the unreviewed code on the self-hosted
+# runner. A maintainer must re-review and re-apply the label, which fires a
+# fresh 'labeled' event and re-runs CI on the new HEAD.
+#
+# This uses pull_request_target because it needs pull-requests:write to manage
+# labels (a read-only fork token cannot), but it runs NO PR code, so it is safe.
+on:
+  pull_request_target:
+    types:
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: revoke-ok-to-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  revoke:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'ok-to-test',
+              });
+              core.info('Removed ok-to-test: new commits require fresh approval.');
+            } catch (error) {
+              if (error.status === 404) {
+                core.info('Label ok-to-test not present; nothing to revoke.');
+              } else {
+                throw error;
+              }
+            }


### PR DESCRIPTION
pull_request_target loads the workflow definition from the base branch,
so changes to the CI YAML cannot be validated in the PR and only surface
as failures after merge. Switch to pull_request so the workflow runs from
the PR's merge-ref and YAML changes are exercised before merge.

The 'ok-to-test' label gate is unchanged and continues to protect the
self-hosted runner; every event field used by the workflow exists
identically in the pull_request payload. As a bonus, fork PRs now run
with a read-only token and no secrets.
---
Bind the ok-to-test approval to a specific revision. When new commits are
pushed, remove the label so the E2E workflow stops running unreviewed code
on the self-hosted runner. A maintainer re-applies the label after review,
which fires a fresh labeled event and re-runs CI on the new HEAD.

Uses pull_request_target for pull-requests:write (label management), but
runs no PR code so it is safe.