### PR TITLE
nvrc: support Kata composable VM images

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -430,6 +430,32 @@ authenticity of new or mutable files, and IPE enforces that only measured,
 policy-approved code ever reaches the CPU, delivering continuous, verifiable
 integrity from boot through runtime.
 
+### **Composable Image Extensions** [#107](https://github.com/NVIDIA/nvrc/issues/107) [#112](https://github.com/NVIDIA/nvrc/issues/112)
+
+Composable VM images split the guest into a measured base rootfs plus
+cold-plugged **extension** images (dm-verity + EROFS), each mounted read-only at
+`/run/kata-extensions/<name>/` before kata-agent starts. Because every extension
+is verity-measured, it inherits the same integrity guarantees as the base
+rootfs, but living on its own superblock forces three controls to be
+reconciled:
+
+* **LoadPin** [#107](https://github.com/NVIDIA/nvrc/issues/107). LoadPin pins
+  kernel file loads (modules, firmware) to the first-mounted rootfs superblock,
+  not to paths. An extension is its own EROFS superblock, so
+  `modprobe --dirname /run/kata-extensions/gpu` and the `/lib/firmware/nvidia`
+  firmware bind (a bind changes the path, not the superblock) fail the pin.
+  Reconciliation: `CONFIG_SECURITY_LOADPIN_VERITY` accepts trusted dm-verity root
+  digests, fed from the extension digests already on the measured cmdline.
+* **SBOM** [#112](https://github.com/NVIDIA/nvrc/issues/112). The base SBOM
+  covers only the base rootfs. Each extension ships its own SBOM bound to its
+  verity root hash, so the guest audit becomes base SBOM + one SBOM per measured
+  extension.
+* **Loader path**. Extension libraries sit on their own superblock at
+  `/run/kata-extensions/gpu/usr/lib/<triplet>` (mirroring the monolith's multiarch
+  layout), off the loader's search path. NVRC rebuilds `ld.so.cache` from the
+  extension and binds it over the read-only base copy, so every consumer
+  (kata-agent, the CDI hooks it runs, and NVRC's own GPU tools) resolves them.
+
 ### **Linux Kernel Runtime Guard (LKRG)** [#110](https://github.com/NVIDIA/nvrc/issues/110)
 
 Linux Kernel Runtime Guard is a self-protecting kernel module that continuously

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,21 @@ processes, and sockets.
 - Single-threaded: NVRC is PID 1 (init) with no threads - no thread::sleep, no
   mutexes, no thread-safe synchronization needed in production code
 
+**Composable image extensions (migration notes):**
+
+- Prefix whitelisting: extensions mount under `/run/kata-extensions/<name>/`, a
+  runtime-built path, so the whitelist needs a prefix rule for that tree, not
+  exact paths. The extension-name charset check (reject `..`/traversal) keeps the
+  prefix sound.
+- Measured arguments: `veritysetup open` takes runtime values (root hash, salt,
+  block counts) from the measured cmdline, so they are as trustworthy as
+  compile-time constants. The future `process` API should encode this (e.g. a
+  `MeasuredArg` type) rather than a blanket `String` escape hatch; `veritysetup`
+  joins the binary whitelist.
+- Loader path: everything (kata-agent, the CDI hooks it runs, and NVRC's own GPU
+  tools) finds the GPU libraries via the loader cache, which NVRC rebuilds from
+  the extension's lib dir.
+
 ## Guidelines
 
 1. **API Compatibility**: Keep std-compatible interfaces for easy exchange

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,8 @@ to tmpfs.
 
 - `anyhow` - yes, supports no_std (disable default features)
 - `log` - yes, supports no_std
-- `nix` - REMOVED, replaced with direct libc syscalls
+- `nix` - direct dependency (mount, reboot, fork, poll, ioctl); no_std goal is
+  to replace it with direct libc syscalls
 - `once_cell` - yes, supports no_std
 - `kernlog` - no, requires std (may need replacement)
 - `rlimit` - needs investigation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,19 @@ dependencies = [
  "nix",
  "once_cell",
  "rlimit",
+ "rstest",
  "serial_test",
  "sha2",
  "tempfile",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -81,6 +91,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +111,31 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
 
 [[package]]
 name = "futures-core"
@@ -114,10 +155,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -125,8 +195,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -156,12 +231,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -203,6 +300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "mktemp"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parking_lot"
@@ -265,6 +368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,12 +404,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rlimit"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -314,30 +499,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea091f6cac2595aa38993f04f4ee692ed43757035c36e67c180b6828356385b1"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serial_test"
-version = "3.5.0"
+name = "sdd"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
- "futures-executor",
- "futures-util",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
  "log",
  "once_cell",
  "parking_lot",
+ "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.5.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -392,6 +618,36 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -502,6 +758,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "NVRC"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cfg-if",
  "kernlog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,8 +14,18 @@ dependencies = [
  "nix",
  "once_cell",
  "rlimit",
+ "rstest",
  "serial_test",
  "tempfile",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -41,6 +51,12 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -107,6 +123,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +160,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -156,6 +190,28 @@ dependencies = [
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
  "windows-targets",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -265,6 +321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,12 +357,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rlimit"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -333,6 +471,32 @@ name = "sdd"
 version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07779b9b918cc05650cb30f404d4d7835d26df37c235eded8a6832e2fb82cca"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serial_test"
@@ -396,6 +560,36 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -500,6 +694,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ panic = 'abort'
 mktemp = "0.5.1"
 tempfile = "3.23.0"
 serial_test = "3.2.0"
+rstest = "0.26.1"
 
 [features]
 confidential = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "NVRC"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ panic = 'abort'
 mktemp = "0.5.1"
 tempfile = "3.23.0"
 serial_test = "3.2.0"
+rstest = "0.26.1"
 
 [features]
 confidential = []

--- a/src/addon.rs
+++ b/src/addon.rs
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) NVIDIA CORPORATION
+
+//! Mount cold-plugged composable VM image addons before kata-agent starts.
+//!
+//! NVRC stands in for the systemd `kata-addon-mount@.service` unit: for each
+//! `kata.addon.<name>.verity_params=...` on the kernel command line, find the
+//! cold-plugged virtio-blk device (serial `addon-<name>`), open it with
+//! dm-verity, and mount the EROFS read-only at `/run/kata-addons/<name>/`. Any
+//! failure panics (powering off the VM): a confidential VM must not run with a
+//! missing or tampered addon.
+//!
+//! Proposal: <https://github.com/kata-containers/kata-containers/pull/13029>
+
+use log::info;
+use nix::mount::MsFlags;
+use std::fs;
+
+use crate::execute::foreground;
+use crate::macros::ResultExt;
+
+const CMDLINE: &str = "/proc/cmdline";
+const SYS_BLOCK: &str = "/sys/block";
+const MOUNT_BASE: &str = "/run/kata-addons";
+const VERITYSETUP: &str = "/usr/sbin/veritysetup";
+
+/// Prefix for the virtio-blk serial and the dm-verity device-mapper target.
+const ADDON_PREFIX: &str = "addon-";
+
+/// dm-verity parameters from `kata.addon.<name>.verity_params`, matching the
+/// comma-separated list emitted by the Kata image builder. Hash is sha256.
+struct VerityParams {
+    root_hash: String,
+    salt: String,
+    data_blocks: u64,
+    data_block_size: u64,
+    hash_block_size: u64,
+}
+
+/// Mount every addon declared on the kernel command line. No-op when no
+/// `kata.addon.*.verity_params` entries are present (non-composable images).
+pub fn mount_all() {
+    let cmdline = fs::read_to_string(CMDLINE).or_panic(format_args!("read {CMDLINE}"));
+    for (name, params) in parse_addons(&cmdline) {
+        mount_addon(&name, &params);
+    }
+}
+
+/// Discover, verity-open and mount a single addon.
+fn mount_addon(name: &str, params: &VerityParams) {
+    let serial = format!("{ADDON_PREFIX}{name}");
+    let dev = find_device_by_serial(SYS_BLOCK, &serial)
+        .unwrap_or_else(|| panic!("addon {name}: no block device with serial {serial}"));
+
+    let (data, hash) = find_partitions(SYS_BLOCK, &dev);
+
+    let dm_name = format!("{ADDON_PREFIX}{name}");
+    let args = verity_args(&dm_name, &data, &hash, params);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    foreground(VERITYSETUP, &arg_refs);
+
+    let mapper = format!("/dev/mapper/{dm_name}");
+    let target = format!("{MOUNT_BASE}/{name}");
+    fs::create_dir_all(&target).or_panic(format_args!("create_dir_all {target}"));
+
+    // NOEXEC omitted: addons ship executables (e.g. attestation-agent).
+    let flags = MsFlags::MS_RDONLY | MsFlags::MS_NOSUID | MsFlags::MS_NODEV;
+    nix::mount::mount(
+        Some(mapper.as_str()),
+        target.as_str(),
+        Some("erofs"),
+        flags,
+        None::<&str>,
+    )
+    .or_panic(format_args!("mount addon {name} ({mapper}) on {target}"));
+
+    info!("mounted addon {name} at {target}");
+}
+
+/// Parse every `kata.addon.<name>.verity_params=...` entry from the kernel
+/// command line into `(name, params)` pairs. Other parameters are ignored.
+fn parse_addons(cmdline: &str) -> Vec<(String, VerityParams)> {
+    cmdline
+        .split_whitespace()
+        .filter_map(|param| param.split_once('='))
+        .filter_map(|(key, value)| {
+            let name = key
+                .strip_prefix("kata.addon.")?
+                .strip_suffix(".verity_params")?;
+            Some((name.to_owned(), parse_verity_params(name, value)))
+        })
+        .collect()
+}
+
+/// Parse the comma-separated verity parameter list. All five fields are
+/// required; anything missing or malformed is fatal (fail-fast).
+fn parse_verity_params(name: &str, value: &str) -> VerityParams {
+    let mut root_hash = None;
+    let mut salt = None;
+    let mut data_blocks = None;
+    let mut data_block_size = None;
+    let mut hash_block_size = None;
+
+    for (key, val) in value.split(',').filter_map(|kv| kv.split_once('=')) {
+        match key {
+            "root_hash" => root_hash = Some(val.to_owned()),
+            "salt" => salt = Some(val.to_owned()),
+            "data_blocks" => data_blocks = Some(parse_u64(name, "data_blocks", val)),
+            "data_block_size" => data_block_size = Some(parse_u64(name, "data_block_size", val)),
+            "hash_block_size" => hash_block_size = Some(parse_u64(name, "hash_block_size", val)),
+            _ => {}
+        }
+    }
+
+    let require = |field: &str, v: Option<String>| {
+        v.unwrap_or_else(|| panic!("addon {name}: verity_params missing {field}"))
+    };
+    let require_num = |field: &str, v: Option<u64>| {
+        v.filter(|n| *n != 0)
+            .unwrap_or_else(|| panic!("addon {name}: verity_params missing or zero {field}"))
+    };
+
+    VerityParams {
+        root_hash: require("root_hash", root_hash),
+        salt: require("salt", salt),
+        data_blocks: require_num("data_blocks", data_blocks),
+        data_block_size: require_num("data_block_size", data_block_size),
+        hash_block_size: require_num("hash_block_size", hash_block_size),
+    }
+}
+
+fn parse_u64(name: &str, field: &str, value: &str) -> u64 {
+    value
+        .parse()
+        .unwrap_or_else(|_| panic!("addon {name}: invalid verity_params {field}={value}"))
+}
+
+/// Build the `veritysetup open` arguments. Params are passed explicitly because
+/// the image is built with `veritysetup format --no-superblock`.
+fn verity_args(dm_name: &str, data: &str, hash: &str, p: &VerityParams) -> Vec<String> {
+    vec![
+        "open".to_owned(),
+        "--no-superblock".to_owned(),
+        "--hash".to_owned(),
+        "sha256".to_owned(),
+        "--data-block-size".to_owned(),
+        p.data_block_size.to_string(),
+        "--hash-block-size".to_owned(),
+        p.hash_block_size.to_string(),
+        "--data-blocks".to_owned(),
+        p.data_blocks.to_string(),
+        "--salt".to_owned(),
+        p.salt.clone(),
+        data.to_owned(),
+        dm_name.to_owned(),
+        hash.to_owned(),
+        p.root_hash.clone(),
+    ]
+}
+
+/// Find the block device with the given `serial` (e.g. `vdb`). Serial-based
+/// discovery is order-independent and needs no udev in the minimal guest.
+fn find_device_by_serial(sys_block: &str, serial: &str) -> Option<String> {
+    fs::read_dir(sys_block).ok()?.flatten().find_map(|entry| {
+        let found = fs::read_to_string(entry.path().join("serial")).ok()?;
+        (found.trim() == serial).then(|| entry.file_name().to_string_lossy().into_owned())
+    })
+}
+
+/// Resolve the data (partition 1) and hash (partition 2) paths, reading the
+/// partition number from sysfs so the device naming convention doesn't matter.
+fn find_partitions(sys_block: &str, dev: &str) -> (String, String) {
+    let dir = format!("{sys_block}/{dev}");
+    let mut data = None;
+    let mut hash = None;
+
+    for entry in fs::read_dir(&dir)
+        .or_panic(format_args!("read_dir {dir}"))
+        .flatten()
+    {
+        let Ok(number) = fs::read_to_string(entry.path().join("partition")) else {
+            continue;
+        };
+        let part = format!("/dev/{}", entry.file_name().to_string_lossy());
+        match number.trim() {
+            "1" => data = Some(part),
+            "2" => hash = Some(part),
+            _ => {}
+        }
+    }
+
+    (
+        data.unwrap_or_else(|| panic!("addon device {dev}: missing data partition (1)")),
+        hash.unwrap_or_else(|| panic!("addon device {dev}: missing hash partition (2)")),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::{fixture, rstest};
+    use tempfile::TempDir;
+
+    const PARAMS: &str = "root_hash=abc123,salt=def456,data_blocks=96512,\
+                          data_block_size=4096,hash_block_size=4096";
+
+    // === parse_verity_params ===
+
+    #[test]
+    fn test_parse_verity_params_valid() {
+        let p = parse_verity_params("coco", PARAMS);
+        assert_eq!(p.root_hash, "abc123");
+        assert_eq!(p.salt, "def456");
+        assert_eq!(p.data_blocks, 96512);
+        assert_eq!(p.data_block_size, 4096);
+        assert_eq!(p.hash_block_size, 4096);
+    }
+
+    #[test]
+    fn test_parse_verity_params_ignores_unknown_keys() {
+        let p = parse_verity_params("coco", &format!("{PARAMS},extra=ignored"));
+        assert_eq!(p.root_hash, "abc123");
+    }
+
+    #[rstest]
+    #[case::missing_root_hash("salt=def,data_blocks=1,data_block_size=4096,hash_block_size=4096")]
+    #[case::zero_data_blocks(
+        "root_hash=a,salt=b,data_blocks=0,data_block_size=4096,hash_block_size=4096"
+    )]
+    #[case::non_numeric(
+        "root_hash=a,salt=b,data_blocks=lots,data_block_size=4096,hash_block_size=4096"
+    )]
+    #[should_panic]
+    fn test_parse_verity_params_invalid(#[case] params: &str) {
+        parse_verity_params("coco", params);
+    }
+
+    // === parse_addons ===
+
+    #[rstest]
+    #[case::single(
+        format!("ro quiet kata.addon.coco.verity_params={PARAMS} console=ttyS0"),
+        vec!["coco"]
+    )]
+    #[case::multiple(
+        format!("kata.addon.coco.verity_params={PARAMS} kata.addon.gpu.verity_params={PARAMS}"),
+        vec!["coco", "gpu"]
+    )]
+    #[case::none("ro quiet console=ttyS0 nvrc.log=debug".to_owned(), vec![])]
+    #[case::other_kata_params("kata.addon.coco.other=x kata.something=y".to_owned(), vec![])]
+    fn test_parse_addons(#[case] cmdline: String, #[case] expected: Vec<&str>) {
+        let addons = parse_addons(&cmdline);
+        let names: Vec<&str> = addons.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, expected);
+    }
+
+    // === verity_args ===
+
+    #[test]
+    fn test_verity_args_order() {
+        let p = parse_verity_params("coco", PARAMS);
+        let args = verity_args("addon-coco", "/dev/vdb1", "/dev/vdb2", &p);
+        assert_eq!(
+            args,
+            vec![
+                "open",
+                "--no-superblock",
+                "--hash",
+                "sha256",
+                "--data-block-size",
+                "4096",
+                "--hash-block-size",
+                "4096",
+                "--data-blocks",
+                "96512",
+                "--salt",
+                "def456",
+                "/dev/vdb1",
+                "addon-coco",
+                "/dev/vdb2",
+                "abc123",
+            ]
+        );
+    }
+
+    // === find_device_by_serial ===
+
+    fn write_serial(sys_block: &TempDir, dev: &str, serial: &str) {
+        let dir = sys_block.path().join(dev);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("serial"), format!("{serial}\n")).unwrap();
+    }
+
+    /// sysfs with a rootfs device and an addon device exposing serials.
+    #[fixture]
+    fn sys_block() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        write_serial(&dir, "vda", "rootfs");
+        write_serial(&dir, "vdb", "addon-coco");
+        dir
+    }
+
+    #[rstest]
+    #[case::match_found("addon-coco", Some("vdb".to_owned()))]
+    #[case::no_match("addon-missing", None)]
+    fn test_find_device_by_serial(
+        sys_block: TempDir,
+        #[case] serial: &str,
+        #[case] expected: Option<String>,
+    ) {
+        let dev = find_device_by_serial(sys_block.path().to_str().unwrap(), serial);
+        assert_eq!(dev, expected);
+    }
+
+    #[test]
+    fn test_find_device_by_serial_missing_serial_file() {
+        let sys_block = TempDir::new().unwrap();
+        // device dir without a serial attribute must be skipped, not panic
+        fs::create_dir_all(sys_block.path().join("vdb")).unwrap();
+        let dev = find_device_by_serial(sys_block.path().to_str().unwrap(), "addon-coco");
+        assert_eq!(dev, None);
+    }
+
+    #[test]
+    fn test_find_device_by_serial_nonexistent_dir() {
+        assert_eq!(
+            find_device_by_serial("/nonexistent/path", "addon-coco"),
+            None
+        );
+    }
+
+    // === find_partitions ===
+
+    fn write_partition(sys_block: &TempDir, dev: &str, part: &str, number: &str) {
+        let dir = sys_block.path().join(dev).join(part);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("partition"), format!("{number}\n")).unwrap();
+    }
+
+    #[test]
+    fn test_find_partitions() {
+        // Addons are cold-plugged as virtio-blk devices (vdX).
+        let sys_block = TempDir::new().unwrap();
+        write_partition(&sys_block, "vdb", "vdb1", "1");
+        write_partition(&sys_block, "vdb", "vdb2", "2");
+        // a non-partition sysfs attribute alongside partitions must be ignored
+        fs::write(sys_block.path().join("vdb").join("size"), "100\n").unwrap();
+
+        let (data, hash) = find_partitions(sys_block.path().to_str().unwrap(), "vdb");
+        assert_eq!(data, "/dev/vdb1");
+        assert_eq!(hash, "/dev/vdb2");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_find_partitions_missing_hash_panics() {
+        let sys_block = TempDir::new().unwrap();
+        write_partition(&sys_block, "vdb", "vdb1", "1");
+        find_partitions(sys_block.path().to_str().unwrap(), "vdb");
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,6 +3,7 @@
 
 use crate::config::update_config_file;
 use crate::execute::background;
+use crate::gpu_extension;
 use crate::kmsg;
 use crate::macros::ResultExt;
 use crate::nvrc::NVRC;
@@ -48,7 +49,10 @@ impl NVRC {
     /// optimizations. Enabled by default since most workloads benefit from it.
     pub fn nvidia_persistenced(&mut self) {
         let mut reader = kmsg::open_kmsg("/dev/kmsg");
-        self.spawn_persistenced("/var/run/nvidia-persistenced", "/bin/nvidia-persistenced");
+        self.spawn_persistenced(
+            "/var/run/nvidia-persistenced",
+            &gpu_extension::path("/bin/nvidia-persistenced"),
+        );
         kmsg::wait_for_marker(&mut reader, "Local RPC services initialized", 120);
     }
 
@@ -63,7 +67,7 @@ impl NVRC {
     /// nv-hostengine is the DCGM backend daemon. Only started when DCGM monitoring
     /// is explicitly requested - not needed for basic GPU workloads.
     pub fn nv_hostengine(&mut self) {
-        self.spawn_hostengine("/bin/nv-hostengine")
+        self.spawn_hostengine(&gpu_extension::path("/bin/nv-hostengine"))
     }
 
     fn spawn_hostengine(&mut self, bin: &str) {
@@ -77,7 +81,7 @@ impl NVRC {
     /// dcgm-exporter exposes GPU metrics for Prometheus. Only started when DCGM
     /// is enabled - adds overhead so disabled by default.
     pub fn dcgm_exporter(&mut self) {
-        self.spawn_dcgm_exporter("/bin/dcgm-exporter")
+        self.spawn_dcgm_exporter(&gpu_extension::path("/bin/dcgm-exporter"))
     }
 
     fn spawn_dcgm_exporter(&mut self, bin: &str) {
@@ -91,13 +95,16 @@ impl NVRC {
     /// NVSwitch fabric manager is only needed for multi-GPU NVLink topologies.
     /// Disabled by default since most VMs have single GPUs.
     pub fn nv_fabricmanager(&mut self, fabric_mode: u8, rail_policy: &str) {
-        fs::copy(FM_CONFIG, FM_RUNTIME_CONFIG)
-            .or_panic(format_args!("copy {FM_CONFIG} to {FM_RUNTIME_CONFIG}"));
+        // The stock config ships in the gpu extension; the editable runtime copy
+        // stays on the writable /run tmpfs.
+        let fm_config = gpu_extension::path(FM_CONFIG);
+        fs::copy(&fm_config, FM_RUNTIME_CONFIG)
+            .or_panic(format_args!("copy {fm_config} to {FM_RUNTIME_CONFIG}"));
         self.configure_fabricmanager(FM_RUNTIME_CONFIG, fabric_mode, rail_policy);
         fs::set_permissions(FM_RUNTIME_CONFIG, fs::Permissions::from_mode(0o400))
             .or_panic(format_args!("set permissions {FM_RUNTIME_CONFIG}"));
         let mut reader = kmsg::open_kmsg("/dev/kmsg");
-        self.spawn_fabricmanager("/bin/nv-fabricmanager");
+        self.spawn_fabricmanager(&gpu_extension::path("/bin/nv-fabricmanager"));
         kmsg::wait_for_marker(&mut reader, "FM starting NvLink Inband", 120);
     }
 
@@ -115,7 +122,7 @@ impl NVRC {
 
     /// CX7 bridges require NVLSM to manage NVLink subnet before FM can initialize the fabric.
     pub fn nv_nvlsm(&mut self) {
-        self.spawn_nvlsm("/sbin/nvlsm")
+        self.spawn_nvlsm(&gpu_extension::path("/sbin/nvlsm"))
     }
 
     fn spawn_nvlsm(&mut self, bin: &str) {
@@ -123,7 +130,8 @@ impl NVRC {
             return;
         };
         let guid_owned = guid.clone();
-        let args = vec!["-F", NVLSM_CONFIG, "-g", &guid_owned, "-f", "stdout"];
+        let nvlsm_config = gpu_extension::path(NVLSM_CONFIG);
+        let args = vec!["-F", &nvlsm_config, "-g", &guid_owned, "-f", "stdout"];
         let child = background(bin, &args);
         self.track_daemon("nvlsm", child);
     }
@@ -287,6 +295,13 @@ mod tests {
         let mut nvrc = NVRC::default();
         // port_guid is None, should be a no-op
         nvrc.spawn_nvlsm("/bin/true");
+    }
+
+    #[test]
+    fn test_nv_nvlsm_skipped_without_guid() {
+        // Resolves the nvlsm binary path, then no-ops without a port GUID.
+        let mut nvrc = NVRC::default();
+        nvrc.nv_nvlsm();
     }
 
     #[test]

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -95,6 +95,8 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore = "miri cannot emulate process spawn")]
+    // spawn fails and or_panic diverges, so no child is ever returned to wait on.
+    #[allow(clippy::zombie_processes)]
     fn test_background_not_found() {
         // Command doesn't exist - should panic
         let result = panic::catch_unwind(|| {

--- a/src/gpu_extension.rs
+++ b/src/gpu_extension.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) NVIDIA CORPORATION
+
+//! Consume the cold-plugged `gpu` extension mounted at `/run/kata-extensions/gpu`.
+//!
+//! With composable images the GPU userspace (libraries, modules, binaries,
+//! configs, firmware) lives in the extension rather than the base rootfs, so each
+//! helper maps its component to the extension mount. With monolithic images (no
+//! extension) they fall back to the canonical rootfs paths.
+
+use std::fs;
+use std::path::Path;
+
+use nix::mount::MsFlags;
+
+use crate::execute::foreground;
+use crate::macros::ResultExt;
+
+/// The `gpu` extension mount ([`crate::guest_extension_image::MOUNT_BASE`]`/gpu`).
+pub const ROOT: &str = "/run/kata-extensions/gpu";
+
+/// Kernel firmware loader's default search path: an empty dir baked into the
+/// read-only base image, over which the extension's firmware tree is bound.
+const FIRMWARE_DST: &str = "/lib/firmware/nvidia";
+
+/// Loader cache regeneration. `ldconfig`/`LDSO_CACHE` come from the base rootfs;
+/// the `_TMP` outputs go to the writable `/run`.
+const LDCONFIG: &str = "/sbin/ldconfig";
+const LDSO_CACHE: &str = "/etc/ld.so.cache";
+const LDSO_CACHE_TMP: &str = "/run/ld.so.cache";
+const LDSO_CONF_TMP: &str = "/run/ld.so.conf";
+
+/// Extension GPU libraries, in the multiarch triplet dir mirroring the monolithic
+/// base image. nvidia-ctk records where it finds each lib and strips the driver
+/// root, so a flat `usr/lib` yields `/usr/lib` container paths its CDI hooks
+/// (create-symlinks/update-ldcache) can't reconcile; the triplet dir yields the
+/// canonical `/usr/lib/<triplet>` the monolithic path already proves out.
+fn lib_dir(root: &str) -> String {
+    format!("{root}/usr/lib/{}-linux-gnu", std::env::consts::ARCH)
+}
+
+pub fn present() -> bool {
+    Path::new(ROOT).is_dir()
+}
+
+/// Map a rootfs component path to its location inside the extension, or return
+/// it unchanged when the extension is absent.
+pub fn path(path: &str) -> String {
+    path_in(present(), ROOT, path)
+}
+
+fn path_in(present: bool, root: &str, path: &str) -> String {
+    if present {
+        format!("{root}{path}")
+    } else {
+        path.to_owned()
+    }
+}
+
+/// `modprobe --dirname` for `module`: the extension root for NVIDIA modules,
+/// `None` otherwise. In-tree modules (`ib_umad`/`mlx5_ib`) stay in the base image.
+pub fn modprobe_dirname(module: &str) -> Option<String> {
+    modprobe_dirname_in(present(), ROOT, module)
+}
+
+fn modprobe_dirname_in(present: bool, root: &str, module: &str) -> Option<String> {
+    (present && module.starts_with("nvidia")).then(|| root.to_owned())
+}
+
+/// `--driver-root` for `nvidia-ctk cdi generate`. nvidia-ctk strips the driver
+/// root from each library's recorded mount path, so passing `<root>` lands the
+/// extension libs at the canonical `/usr/lib/<triplet>` in the container. Must be
+/// paired with `--dev-root=/` ([`DEV_ROOT`]) so device
+/// discovery still finds the real guest `/dev/nvidia*` nodes. `None` for the
+/// monolithic image.
+pub fn driver_root() -> Option<String> {
+    driver_root_in(present(), ROOT)
+}
+
+fn driver_root_in(present: bool, root: &str) -> Option<String> {
+    present.then(|| root.to_owned())
+}
+
+/// `--dev-root` for `nvidia-ctk cdi generate`. Counteracts [`driver_root`]'s
+/// strip, which would otherwise drop the real guest `/dev/nvidia*` nodes.
+pub const DEV_ROOT: &str = "/";
+
+/// `--nvidia-cdi-hook-path` for `nvidia-ctk cdi generate`. The generated
+/// createContainer hooks run `nvidia-cdi-hook` from the guest; it lives in the
+/// extension, not nvidia-ctk's `/usr/bin` default, so without this the hooks
+/// silently no-op and CUDA breaks. `None` for the monolithic image.
+pub fn cdi_hook_path() -> Option<String> {
+    cdi_hook_path_in(present(), ROOT)
+}
+
+fn cdi_hook_path_in(present: bool, root: &str) -> Option<String> {
+    present.then(|| format!("{root}/bin/nvidia-cdi-hook"))
+}
+
+/// attestation-agent variant launching the NVIDIA attester; matches
+/// `[process.variants.nvidia]` in the extension's `components.toml`.
+pub const ATTESTER_VARIANT_NVIDIA: &str = "nvidia";
+
+/// Attester variant kata-agent should use (via `KATA_ATTESTER_VARIANT`). With the
+/// GPU extension the GPU must be attested, but the stock attester emits no `gpu0`
+/// evidence so a GPU KBS policy can never pass; the `nvidia` variant does. `None`
+/// (stock) without the extension: nothing to attest.
+pub fn attester_variant() -> Option<&'static str> {
+    attester_variant_in(present())
+}
+
+fn attester_variant_in(present: bool) -> Option<&'static str> {
+    present.then_some(ATTESTER_VARIANT_NVIDIA)
+}
+
+pub fn setup() {
+    bind_firmware();
+    refresh_ldcache();
+}
+
+/// Add the extension's lib dir to the loader cache so kata-agent and the CDI
+/// hooks it runs resolve the GPU libraries without an inherited `LD_LIBRARY_PATH`.
+/// Base rootfs is read-only, so build on `/run` and bind over the cache.
+fn refresh_ldcache() {
+    if !present() {
+        return;
+    }
+    refresh_ldcache_in(&lib_dir(ROOT));
+}
+
+fn refresh_ldcache_in(lib_dir: &str) {
+    fs::write(LDSO_CONF_TMP, ldso_conf(lib_dir)).or_panic(format_args!("write {LDSO_CONF_TMP}"));
+    // -X: leave the read-only lib dir's symlinks alone; -f/-C: our conf, write to /run.
+    foreground(LDCONFIG, &["-X", "-f", LDSO_CONF_TMP, "-C", LDSO_CACHE_TMP]);
+    bind_over(LDSO_CACHE_TMP, LDSO_CACHE);
+    info!("gpu extension: cached libraries from {lib_dir}");
+}
+
+/// Our `-f` conf replaces the base one, so re-include its `.conf.d` before the
+/// extension lib dir.
+fn ldso_conf(lib_dir: &str) -> String {
+    format!("include /etc/ld.so.conf.d/*.conf\n{lib_dir}\n")
+}
+
+/// Bind the extension firmware onto the kernel's default search path so
+/// `request_firmware` (e.g. GSP) finds it. Skipped when the extension ships none.
+fn bind_firmware() {
+    bind_firmware_in(&format!("{ROOT}/lib/firmware/nvidia"), FIRMWARE_DST);
+}
+
+fn bind_firmware_in(src: &str, dst: &str) {
+    if !Path::new(src).is_dir() {
+        return;
+    }
+    bind_over(src, dst);
+    info!("gpu extension: bound firmware {src} -> {dst}");
+}
+
+/// Bind `src` (file or dir) onto `dst`. `dst` must already exist: the base
+/// rootfs is read-only, so the mountpoint is baked in at image build time.
+fn bind_over(src: &str, dst: &str) {
+    nix::mount::mount(Some(src), dst, None::<&str>, MsFlags::MS_BIND, None::<&str>)
+        .or_panic(format_args!("bind {src} -> {dst}"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::require_root;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // === ROOT / MOUNT_BASE contract ===
+
+    #[test]
+    fn test_extension_root_matches_mount_base() {
+        assert_eq!(
+            ROOT,
+            format!("{}/gpu", crate::guest_extension_image::MOUNT_BASE)
+        );
+    }
+
+    // === path ===
+
+    #[test]
+    fn test_path_with_extension() {
+        assert_eq!(
+            path_in(true, ROOT, "/bin/nvidia-smi"),
+            format!("{ROOT}/bin/nvidia-smi")
+        );
+    }
+
+    #[test]
+    fn test_path_without_extension() {
+        assert_eq!(path_in(false, ROOT, "/bin/nvidia-smi"), "/bin/nvidia-smi");
+    }
+
+    #[test]
+    fn test_path_config() {
+        assert_eq!(
+            path_in(true, ROOT, "/usr/share/nvidia/nvlsm/nvlsm.conf"),
+            format!("{ROOT}/usr/share/nvidia/nvlsm/nvlsm.conf")
+        );
+    }
+
+    // === modprobe_dirname ===
+
+    #[test]
+    fn test_modprobe_dirname_nvidia_with_extension() {
+        assert_eq!(
+            modprobe_dirname_in(true, ROOT, "nvidia"),
+            Some(ROOT.to_owned())
+        );
+        assert_eq!(
+            modprobe_dirname_in(true, ROOT, "nvidia-uvm"),
+            Some(ROOT.to_owned())
+        );
+    }
+
+    #[test]
+    fn test_modprobe_dirname_nvidia_without_extension() {
+        assert_eq!(modprobe_dirname_in(false, ROOT, "nvidia"), None);
+    }
+
+    #[test]
+    fn test_modprobe_dirname_base_module_with_extension() {
+        // In-tree modules ship in the base image, not the extension.
+        assert_eq!(modprobe_dirname_in(true, ROOT, "ib_umad"), None);
+        assert_eq!(modprobe_dirname_in(true, ROOT, "mlx5_ib"), None);
+    }
+
+    // === driver_root ===
+
+    #[test]
+    fn test_driver_root_with_extension() {
+        assert_eq!(driver_root_in(true, ROOT), Some(ROOT.to_owned()));
+    }
+
+    #[test]
+    fn test_driver_root_without_extension() {
+        assert_eq!(driver_root_in(false, ROOT), None);
+    }
+
+    // === cdi_hook_path ===
+
+    #[test]
+    fn test_cdi_hook_path_with_extension() {
+        assert_eq!(
+            cdi_hook_path_in(true, ROOT),
+            Some(format!("{ROOT}/bin/nvidia-cdi-hook"))
+        );
+    }
+
+    #[test]
+    fn test_cdi_hook_path_without_extension() {
+        assert_eq!(cdi_hook_path_in(false, ROOT), None);
+    }
+
+    // === attester_variant ===
+
+    #[test]
+    fn test_attester_variant_with_extension() {
+        assert_eq!(attester_variant_in(true), Some(ATTESTER_VARIANT_NVIDIA));
+    }
+
+    #[test]
+    fn test_attester_variant_without_extension() {
+        assert_eq!(attester_variant_in(false), None);
+    }
+
+    // === public wrappers (monolithic image: no extension mounted) ===
+
+    // The public helpers read the real filesystem via present(). In CI/test
+    // environments the extension is never mounted, so they must take the
+    // monolithic fallback. Guarded so a host that happens to have the mount does
+    // not fail the suite.
+    #[test]
+    fn test_public_helpers_fall_back_without_extension() {
+        if present() {
+            return;
+        }
+        assert_eq!(path("/bin/nvidia-smi"), "/bin/nvidia-smi");
+        assert_eq!(modprobe_dirname("nvidia"), None);
+        assert_eq!(driver_root(), None);
+        assert_eq!(cdi_hook_path(), None);
+        assert_eq!(attester_variant(), None);
+        setup(); // no-op without the extension
+    }
+
+    // === bind_firmware ===
+
+    #[test]
+    fn test_bind_firmware_skips_without_src() {
+        // No firmware tree in the extension: no-op, and in particular no attempt
+        // to bind onto the (nonexistent) destination. Needs no root.
+        bind_firmware_in("/nonexistent/firmware/src", "/nonexistent/firmware/dst");
+    }
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "root-gated: require_root re-execs the test binary via sudo, which miri cannot emulate"
+    )]
+    fn test_bind_firmware_binds_when_src_present() {
+        require_root();
+        let src = TempDir::new().unwrap();
+        let dst = TempDir::new().unwrap();
+        fs::write(src.path().join("gsp.bin.txt"), "firmware").unwrap();
+
+        bind_firmware_in(src.path().to_str().unwrap(), dst.path().to_str().unwrap());
+
+        let visible = dst.path().join("gsp.bin.txt");
+        assert!(visible.exists());
+        assert_eq!(fs::read_to_string(visible).unwrap(), "firmware");
+
+        nix::mount::umount(dst.path()).unwrap();
+    }
+
+    // === ldso_conf ===
+
+    #[test]
+    fn test_ldso_conf_includes_base_and_extension() {
+        assert_eq!(
+            ldso_conf(&format!("{ROOT}/usr/lib")),
+            format!("include /etc/ld.so.conf.d/*.conf\n{ROOT}/usr/lib\n")
+        );
+    }
+
+    // === bind_over (needs root for mount(2)) ===
+
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "root-gated: require_root re-execs the test binary via sudo, which miri cannot emulate"
+    )]
+    fn test_bind_over_makes_source_visible() {
+        require_root();
+        let src = TempDir::new().unwrap();
+        let dst = TempDir::new().unwrap();
+        fs::write(src.path().join("gsp.bin.txt"), "firmware").unwrap();
+
+        let src_str = src.path().to_str().unwrap();
+        let dst_str = dst.path().to_str().unwrap();
+        bind_over(src_str, dst_str);
+
+        let visible = dst.path().join("gsp.bin.txt");
+        assert!(visible.exists());
+        assert_eq!(fs::read_to_string(visible).unwrap(), "firmware");
+
+        nix::mount::umount(dst.path()).unwrap();
+    }
+}

--- a/src/guest_extension_image.rs
+++ b/src/guest_extension_image.rs
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) NVIDIA CORPORATION
+
+//! Mount cold-plugged composable VM image extensions before kata-agent starts.
+//!
+//! For each virtio-blk extension (serial `extension-<name>`) NVRC dm-verity-opens
+//! the device with `kata.extension.<name>.verity_params` from the (measured)
+//! kernel command line and mounts the EROFS read-only at
+//! `/run/kata-extensions/<name>/`.
+//!
+//! Being confidential-only, NVRC fails closed rather than downgrade: discovery is
+//! device-driven and reconciled 1:1 with the command line, with no unmeasured
+//! raw-mount fallback. Every extension must be verity-measured.
+//!
+//!   device + params   -> verify and mount
+//!   device, no params -> panic (verity stripped)
+//!   params, no device -> panic (mismatch / missing extension)
+//!
+//! See ARCHITECTURE.md ("Composable Image Extensions") for the design rationale.
+
+use log::info;
+use nix::mount::MsFlags;
+use std::fs;
+
+use crate::execute::foreground;
+use crate::macros::ResultExt;
+
+const CMDLINE: &str = "/proc/cmdline";
+const SYS_BLOCK: &str = "/sys/block";
+/// Extension mount tree (`<MOUNT_BASE>/<name>`); source of truth for
+/// [`crate::gpu_extension::ROOT`].
+pub(crate) const MOUNT_BASE: &str = "/run/kata-extensions";
+const VERITYSETUP: &str = "/usr/sbin/veritysetup";
+
+/// Prefix for the virtio-blk serial and the dm-verity device-mapper target.
+const EXTENSION_PREFIX: &str = "extension-";
+
+/// Kernel cmdline key wrapping a per-extension verity param list:
+/// `kata.extension.<name>.verity_params`.
+const CMDLINE_KEY_PREFIX: &str = "kata.extension.";
+const CMDLINE_KEY_SUFFIX: &str = ".verity_params";
+
+/// dm-verity parameters from `kata.extension.<name>.verity_params`, matching the
+/// comma-separated list emitted by the Kata image builder. Hash is sha256.
+struct VerityParams {
+    root_hash: String,
+    salt: String,
+    data_blocks: u64,
+    data_block_size: u64,
+    hash_block_size: u64,
+}
+
+/// Mount every cold-plugged extension; no-op on non-composable images.
+pub fn mount_all() {
+    let cmdline = fs::read_to_string(CMDLINE).or_panic(format_args!("read {CMDLINE}"));
+    let params = parse_extensions(&cmdline);
+    let devices = discover_extensions(SYS_BLOCK);
+    for (name, dev, verity) in plan_mounts(&params, &devices) {
+        mount_extension(name, dev, verity);
+    }
+}
+
+/// Reconcile discovered devices against command-line params, failing closed:
+/// every device must have params and every param a device.
+fn plan_mounts<'a>(
+    params: &'a [(String, VerityParams)],
+    devices: &'a [(String, String)],
+) -> Vec<(&'a str, &'a str, &'a VerityParams)> {
+    for (name, _) in params {
+        if !devices.iter().any(|(dev_name, _)| dev_name == name) {
+            panic!(
+                "extension {name}: verity params on cmdline but no {EXTENSION_PREFIX}{name} device"
+            );
+        }
+    }
+
+    devices
+        .iter()
+        .map(|(name, dev)| {
+            let verity = params
+                .iter()
+                .find(|(param_name, _)| param_name == name)
+                .map(|(_, verity)| verity)
+                .unwrap_or_else(|| {
+                    panic!("extension {name}: device present but no verity params; refusing unverified mount")
+                });
+            (name.as_str(), dev.as_str(), verity)
+        })
+        .collect()
+}
+
+fn mount_extension(name: &str, dev: &str, params: &VerityParams) {
+    let (data, hash) = find_partitions(SYS_BLOCK, dev);
+
+    let dm_name = format!("{EXTENSION_PREFIX}{name}");
+    let args = verity_args(&dm_name, &data, &hash, params);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    foreground(VERITYSETUP, &arg_refs);
+
+    let mapper = format!("/dev/mapper/{dm_name}");
+    let target = format!("{MOUNT_BASE}/{name}");
+    fs::create_dir_all(&target).or_panic(format_args!("create_dir_all {target}"));
+
+    // No NOEXEC: extensions ship executables (e.g. attestation-agent).
+    let flags = MsFlags::MS_RDONLY | MsFlags::MS_NOSUID | MsFlags::MS_NODEV;
+    nix::mount::mount(
+        Some(mapper.as_str()),
+        target.as_str(),
+        Some("erofs"),
+        flags,
+        None::<&str>,
+    )
+    .or_panic(format_args!(
+        "mount extension {name} ({mapper}) on {target}"
+    ));
+
+    info!("mounted extension {name} at {target}");
+}
+
+/// Parse `kata.extension.<name>.verity_params` entries into `(name, params)`.
+fn parse_extensions(cmdline: &str) -> Vec<(String, VerityParams)> {
+    cmdline
+        .split_whitespace()
+        .filter_map(|param| param.split_once('='))
+        .filter_map(|(key, value)| {
+            let name = key
+                .strip_prefix(CMDLINE_KEY_PREFIX)?
+                .strip_suffix(CMDLINE_KEY_SUFFIX)?;
+            Some((name.to_owned(), parse_verity_params(name, value)))
+        })
+        .collect()
+}
+
+/// All five fields are required; missing or malformed is fatal (fail closed).
+fn parse_verity_params(name: &str, value: &str) -> VerityParams {
+    let mut root_hash = None;
+    let mut salt = None;
+    let mut data_blocks = None;
+    let mut data_block_size = None;
+    let mut hash_block_size = None;
+
+    for (key, val) in value.split(',').filter_map(|kv| kv.split_once('=')) {
+        match key {
+            "root_hash" => root_hash = Some(val.to_owned()),
+            "salt" => salt = Some(val.to_owned()),
+            "data_blocks" => data_blocks = Some(parse_u64(name, "data_blocks", val)),
+            "data_block_size" => data_block_size = Some(parse_u64(name, "data_block_size", val)),
+            "hash_block_size" => hash_block_size = Some(parse_u64(name, "hash_block_size", val)),
+            _ => {}
+        }
+    }
+
+    let require = |field: &str, v: Option<String>| {
+        v.unwrap_or_else(|| panic!("extension {name}: verity_params missing {field}"))
+    };
+    let require_num = |field: &str, v: Option<u64>| {
+        v.filter(|n| *n != 0)
+            .unwrap_or_else(|| panic!("extension {name}: verity_params missing or zero {field}"))
+    };
+
+    VerityParams {
+        root_hash: require("root_hash", root_hash),
+        salt: require("salt", salt),
+        data_blocks: require_num("data_blocks", data_blocks),
+        data_block_size: require_num("data_block_size", data_block_size),
+        hash_block_size: require_num("hash_block_size", hash_block_size),
+    }
+}
+
+fn parse_u64(name: &str, field: &str, value: &str) -> u64 {
+    value
+        .parse()
+        .unwrap_or_else(|_| panic!("extension {name}: invalid verity_params {field}={value}"))
+}
+
+/// `veritysetup open` args, passed explicitly because the image is built
+/// `--no-superblock`.
+fn verity_args(dm_name: &str, data: &str, hash: &str, p: &VerityParams) -> Vec<String> {
+    vec![
+        "open".to_owned(),
+        "--no-superblock".to_owned(),
+        "--hash".to_owned(),
+        "sha256".to_owned(),
+        "--data-block-size".to_owned(),
+        p.data_block_size.to_string(),
+        "--hash-block-size".to_owned(),
+        p.hash_block_size.to_string(),
+        "--data-blocks".to_owned(),
+        p.data_blocks.to_string(),
+        "--salt".to_owned(),
+        p.salt.clone(),
+        data.to_owned(),
+        dm_name.to_owned(),
+        hash.to_owned(),
+        p.root_hash.clone(),
+    ]
+}
+
+/// Discover extension devices by `extension-<name>` serial into `(name, dev)`
+/// pairs (e.g. `("coco", "vdb")`). Serial-based, so order-independent and no udev.
+fn discover_extensions(sys_block: &str) -> Vec<(String, String)> {
+    let Ok(entries) = fs::read_dir(sys_block) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let serial = fs::read_to_string(entry.path().join("serial")).ok()?;
+            let name = serial.trim().strip_prefix(EXTENSION_PREFIX)?;
+            // Name is a path component under MOUNT_BASE: reject traversal/bad chars.
+            if name.is_empty()
+                || name.bytes().all(|b| b == b'.')
+                || !name
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'-' | b'.'))
+            {
+                panic!("invalid extension name {name:?}");
+            }
+            Some((
+                name.to_owned(),
+                entry.file_name().to_string_lossy().into_owned(),
+            ))
+        })
+        .collect()
+}
+
+/// Data (partition 1) and hash (partition 2) paths, read from sysfs so the
+/// naming convention (`vdb1` vs `nvme0n1p1`) does not matter.
+fn find_partitions(sys_block: &str, dev: &str) -> (String, String) {
+    let dir = format!("{sys_block}/{dev}");
+    let mut data = None;
+    let mut hash = None;
+
+    for entry in fs::read_dir(&dir)
+        .or_panic(format_args!("read_dir {dir}"))
+        .flatten()
+    {
+        let Ok(number) = fs::read_to_string(entry.path().join("partition")) else {
+            continue;
+        };
+        let part = format!("/dev/{}", entry.file_name().to_string_lossy());
+        match number.trim() {
+            "1" => data = Some(part),
+            "2" => hash = Some(part),
+            _ => {}
+        }
+    }
+
+    (
+        data.unwrap_or_else(|| panic!("extension device {dev}: missing data partition (1)")),
+        hash.unwrap_or_else(|| panic!("extension device {dev}: missing hash partition (2)")),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::{fixture, rstest};
+    use tempfile::TempDir;
+
+    const PARAMS: &str = "root_hash=abc123,salt=def456,data_blocks=96512,\
+                          data_block_size=4096,hash_block_size=4096";
+
+    // === parse_verity_params ===
+
+    #[test]
+    fn test_parse_verity_params_valid() {
+        let p = parse_verity_params("coco", PARAMS);
+        assert_eq!(p.root_hash, "abc123");
+        assert_eq!(p.salt, "def456");
+        assert_eq!(p.data_blocks, 96512);
+        assert_eq!(p.data_block_size, 4096);
+        assert_eq!(p.hash_block_size, 4096);
+    }
+
+    #[test]
+    fn test_parse_verity_params_ignores_unknown_keys() {
+        let p = parse_verity_params("coco", &format!("{PARAMS},extra=ignored"));
+        assert_eq!(p.root_hash, "abc123");
+    }
+
+    #[rstest]
+    #[case::missing_root_hash("salt=def,data_blocks=1,data_block_size=4096,hash_block_size=4096")]
+    #[case::zero_data_blocks(
+        "root_hash=a,salt=b,data_blocks=0,data_block_size=4096,hash_block_size=4096"
+    )]
+    #[case::non_numeric(
+        "root_hash=a,salt=b,data_blocks=lots,data_block_size=4096,hash_block_size=4096"
+    )]
+    #[should_panic]
+    fn test_parse_verity_params_invalid(#[case] params: &str) {
+        parse_verity_params("coco", params);
+    }
+
+    // === parse_extensions ===
+
+    #[rstest]
+    #[case::single(
+        format!("ro quiet kata.extension.coco.verity_params={PARAMS} console=ttyS0"),
+        vec!["coco"]
+    )]
+    #[case::multiple(
+        format!("kata.extension.coco.verity_params={PARAMS} kata.extension.gpu.verity_params={PARAMS}"),
+        vec!["coco", "gpu"]
+    )]
+    #[case::none("ro quiet console=ttyS0 nvrc.log=debug".to_owned(), vec![])]
+    #[case::other_kata_params("kata.extension.coco.other=x kata.something=y".to_owned(), vec![])]
+    fn test_parse_extensions(#[case] cmdline: String, #[case] expected: Vec<&str>) {
+        let extensions = parse_extensions(&cmdline);
+        let names: Vec<&str> = extensions.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, expected);
+    }
+
+    // === verity_args ===
+
+    #[test]
+    fn test_verity_args_order() {
+        let p = parse_verity_params("coco", PARAMS);
+        let args = verity_args("extension-coco", "/dev/vdb1", "/dev/vdb2", &p);
+        assert_eq!(
+            args,
+            vec![
+                "open",
+                "--no-superblock",
+                "--hash",
+                "sha256",
+                "--data-block-size",
+                "4096",
+                "--hash-block-size",
+                "4096",
+                "--data-blocks",
+                "96512",
+                "--salt",
+                "def456",
+                "/dev/vdb1",
+                "extension-coco",
+                "/dev/vdb2",
+                "abc123",
+            ]
+        );
+    }
+
+    // === discover_extensions ===
+
+    fn write_serial(sys_block: &TempDir, dev: &str, serial: &str) {
+        let dir = sys_block.path().join(dev);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("serial"), format!("{serial}\n")).unwrap();
+    }
+
+    /// sysfs with a rootfs device and a coco extension device exposing serials.
+    #[fixture]
+    fn sys_block() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        write_serial(&dir, "vda", "rootfs");
+        write_serial(&dir, "vdb", "extension-coco");
+        dir
+    }
+
+    #[rstest]
+    fn test_discover_extensions(sys_block: TempDir) {
+        let found = discover_extensions(sys_block.path().to_str().unwrap());
+        assert_eq!(found, vec![("coco".to_owned(), "vdb".to_owned())]);
+    }
+
+    #[test]
+    fn test_discover_extensions_none() {
+        let sys_block = TempDir::new().unwrap();
+        write_serial(&sys_block, "vda", "rootfs");
+        assert!(discover_extensions(sys_block.path().to_str().unwrap()).is_empty());
+    }
+
+    #[test]
+    fn test_discover_extensions_missing_serial_file() {
+        let sys_block = TempDir::new().unwrap();
+        // device dir without a serial attribute must be skipped, not panic
+        fs::create_dir_all(sys_block.path().join("vdb")).unwrap();
+        assert!(discover_extensions(sys_block.path().to_str().unwrap()).is_empty());
+    }
+
+    #[test]
+    fn test_discover_extensions_nonexistent_dir() {
+        assert!(discover_extensions("/nonexistent/path").is_empty());
+    }
+
+    #[test]
+    fn test_discover_extensions_allows_safe_name_chars() {
+        let sys_block = TempDir::new().unwrap();
+        write_serial(&sys_block, "vdb", "extension-gpu.v2_0-rc1");
+        let found = discover_extensions(sys_block.path().to_str().unwrap());
+        assert_eq!(found, vec![("gpu.v2_0-rc1".to_owned(), "vdb".to_owned())]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_discover_extensions_empty_name_panics() {
+        let sys_block = TempDir::new().unwrap();
+        write_serial(&sys_block, "vdb", "extension-");
+        discover_extensions(sys_block.path().to_str().unwrap());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_discover_extensions_invalid_name_panics() {
+        let sys_block = TempDir::new().unwrap();
+        // A path separator in the name could escape MOUNT_BASE: must fail closed.
+        write_serial(&sys_block, "vdb", "extension-../evil");
+        discover_extensions(sys_block.path().to_str().unwrap());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_discover_extensions_dots_only_name_panics() {
+        let sys_block = TempDir::new().unwrap();
+        // `extension-..` -> name `..` -> target `/run/kata-extensions/..` == `/run`.
+        write_serial(&sys_block, "vdb", "extension-..");
+        discover_extensions(sys_block.path().to_str().unwrap());
+    }
+
+    // === mount_all (no-op reconciliation) ===
+
+    #[test]
+    fn test_mount_all_noop_without_extensions() {
+        // With no kata.extension.* params and no extension- devices, mount_all()
+        // reconciles to an empty plan and mounts nothing. Guarded so it never
+        // attempts a real mount on a host that does have extensions configured.
+        let cmdline = fs::read_to_string(CMDLINE).unwrap_or_default();
+        if !parse_extensions(&cmdline).is_empty() || !discover_extensions(SYS_BLOCK).is_empty() {
+            return;
+        }
+        mount_all();
+    }
+
+    // === plan_mounts (fail-closed reconciliation) ===
+
+    fn params(names: &[&str]) -> Vec<(String, VerityParams)> {
+        names
+            .iter()
+            .map(|n| (n.to_string(), parse_verity_params(n, PARAMS)))
+            .collect()
+    }
+
+    fn devices(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(n, d)| (n.to_string(), d.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_plan_mounts_matched() {
+        let p = params(&["coco"]);
+        let d = devices(&[("coco", "vdb")]);
+        let plan = plan_mounts(&p, &d);
+        assert_eq!(plan.len(), 1);
+        assert_eq!(plan[0].0, "coco");
+        assert_eq!(plan[0].1, "vdb");
+    }
+
+    #[test]
+    fn test_plan_mounts_empty() {
+        assert!(plan_mounts(&[], &[]).is_empty());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_plan_mounts_param_without_device() {
+        plan_mounts(&params(&["coco"]), &[]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_plan_mounts_device_without_param() {
+        plan_mounts(&[], &devices(&[("coco", "vdb")]));
+    }
+
+    // === find_partitions ===
+
+    fn write_partition(sys_block: &TempDir, dev: &str, part: &str, number: &str) {
+        let dir = sys_block.path().join(dev).join(part);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("partition"), format!("{number}\n")).unwrap();
+    }
+
+    #[test]
+    fn test_find_partitions() {
+        // Extensions are cold-plugged as virtio-blk devices (vdX).
+        let sys_block = TempDir::new().unwrap();
+        write_partition(&sys_block, "vdb", "vdb1", "1");
+        write_partition(&sys_block, "vdb", "vdb2", "2");
+        // a non-partition sysfs attribute alongside partitions must be ignored
+        fs::write(sys_block.path().join("vdb").join("size"), "100\n").unwrap();
+
+        let (data, hash) = find_partitions(sys_block.path().to_str().unwrap(), "vdb");
+        assert_eq!(data, "/dev/vdb1");
+        assert_eq!(hash, "/dev/vdb2");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_find_partitions_missing_hash_panics() {
+        let sys_block = TempDir::new().unwrap();
+        write_partition(&sys_block, "vdb", "vdb1", "1");
+        find_partitions(sys_block.path().to_str().unwrap(), "vdb");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_find_partitions_missing_data_panics() {
+        let sys_block = TempDir::new().unwrap();
+        write_partition(&sys_block, "vdb", "vdb2", "2");
+        find_partitions(sys_block.path().to_str().unwrap(), "vdb");
+    }
+}

--- a/src/kata_agent.rs
+++ b/src/kata_agent.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) NVIDIA CORPORATION
 
+use crate::gpu_extension;
 use log::debug;
 use nix::unistd::{fork, ForkResult};
 use rlimit::{setrlimit, Resource};
@@ -11,6 +12,11 @@ use std::thread::sleep;
 use std::time::Duration;
 
 const KATA_AGENT_PATH: &str = "/usr/bin/kata-agent";
+
+/// Env var kata-agent reads to pick its attestation-agent. Set to
+/// [`gpu_extension::ATTESTER_VARIANT_NVIDIA`] when the GPU extension is present, unset
+/// otherwise. Contract shared with kata-agent (`src/agent/src/main.rs`).
+const ATTESTER_VARIANT_ENV: &str = "KATA_ATTESTER_VARIANT";
 
 /// Syslog polling runs indefinitely in production—VM lifetime measured in hours/days,
 /// not the 136 years this represents. Using u32::MAX avoids overflow concerns.
@@ -34,17 +40,28 @@ fn agent_setup() {
     debug!("kata-agent RLIMIT_NOFILE: {:?}", lim);
 }
 
+/// Build the kata-agent command, injecting the attester-variant env var when
+/// set. Split from [`exec_agent`] so the env wiring is unit-testable. GPU libs
+/// resolve via the loader cache ([`gpu_extension::setup`]), not `LD_LIBRARY_PATH`.
+fn agent_command(cmd: &str, attester_variant: Option<&str>) -> Command {
+    let mut command = Command::new(cmd);
+    if let Some(variant) = attester_variant {
+        command.env(ATTESTER_VARIANT_ENV, variant);
+    }
+    command
+}
+
 /// exec() replaces this process with kata-agent, so it only returns on failure.
 /// We want kata-agent to become PID 1's child for proper process hierarchy.
-fn exec_agent(cmd: &str) {
-    let err = Command::new(cmd).exec();
+fn exec_agent(cmd: &str, attester_variant: Option<&str>) {
+    let err = agent_command(cmd, attester_variant).exec();
     panic!("exec {cmd} failed: {err}");
 }
 
 /// Path parameter enables testing with /bin/true instead of real kata-agent
-fn kata_agent(path: &str) {
+fn kata_agent(path: &str, attester_variant: Option<&str>) {
     agent_setup();
-    exec_agent(path);
+    exec_agent(path, attester_variant);
 }
 
 /// Drains `/dev/log` (bound in `main()` before fork) into `/run/syslog.log`.
@@ -71,7 +88,7 @@ pub fn fork_agent(timeout_secs: u32) {
     // 4. No locks or mutexes exist that could deadlock in child
     match unsafe { fork() }.expect("fork agent") {
         ForkResult::Parent { .. } => {
-            kata_agent(KATA_AGENT_PATH);
+            kata_agent(KATA_AGENT_PATH, gpu_extension::attester_variant());
         }
         ForkResult::Child => {
             syslog_loop(timeout_secs);
@@ -123,9 +140,36 @@ mod tests {
     fn test_exec_agent_not_found() {
         // exec_agent with nonexistent command panics (doesn't exec)
         let result = panic::catch_unwind(|| {
-            exec_agent("/nonexistent/command");
+            exec_agent("/nonexistent/command", None);
         });
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_agent_command_injects_attester_variant() {
+        use std::ffi::OsStr;
+        let cmd = agent_command("/bin/true", Some(gpu_extension::ATTESTER_VARIANT_NVIDIA));
+        let found = cmd.get_envs().any(|(k, v)| {
+            k == OsStr::new(ATTESTER_VARIANT_ENV)
+                && v == Some(OsStr::new(gpu_extension::ATTESTER_VARIANT_NVIDIA))
+        });
+        assert!(
+            found,
+            "expected {ATTESTER_VARIANT_ENV} to be set on the agent command"
+        );
+    }
+
+    #[test]
+    fn test_agent_command_no_variant_leaves_env_unset() {
+        use std::ffi::OsStr;
+        let cmd = agent_command("/bin/true", None);
+        let found = cmd
+            .get_envs()
+            .any(|(k, _)| k == OsStr::new(ATTESTER_VARIANT_ENV));
+        assert!(
+            !found,
+            "did not expect {ATTESTER_VARIANT_ENV} without a GPU extension"
+        );
     }
 
     #[test]
@@ -148,7 +192,7 @@ mod tests {
             ForkResult::Child => {
                 set_test_panic_hook();
                 // Setup succeeds, exec panics
-                kata_agent("/nonexistent/agent");
+                kata_agent("/nonexistent/agent", None);
                 std::process::exit(0); // Won't reach here
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@
 pub mod config;
 pub mod daemon;
 pub mod execute;
+pub mod gpu_extension;
+pub mod guest_extension_image;
 pub mod hash;
 pub mod kata_agent;
 pub mod kernel_params;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(non_snake_case)]
 //! The main binary uses these modules internally.
 
+pub mod addon;
 pub mod config;
 pub mod daemon;
 pub mod execute;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@
 mod config;
 mod daemon;
 mod execute;
+mod gpu_extension;
+mod guest_extension_image;
 mod hash;
 mod infiniband;
 mod init;
@@ -104,6 +106,12 @@ fn main() {
     syslog::poll();
     init.process_kernel_params(None);
     hash::self_exe();
+
+    // Before disable_modules_loading() so dm-verity/erofs modules can still load.
+    guest_extension_image::mount_all();
+
+    // Expose gpu-extension libs/firmware before any driver load. No-op if absent.
+    gpu_extension::setup();
 
     let detected = mode::detect();
     match detected.mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) NVIDIA CORPORATION
 
+mod addon;
 mod config;
 mod daemon;
 mod execute;
@@ -99,6 +100,10 @@ fn main() {
     kmsg::kernlog_setup();
     syslog::poll();
     init.process_kernel_params(None);
+
+    // Mount addon images before kata-agent; before disable_modules_loading()
+    // so dm-verity/erofs can still be loaded if built as modules.
+    addon::mount_all();
 
     let detected = mode::detect();
     match detected.mode {

--- a/src/modprobe.rs
+++ b/src/modprobe.rs
@@ -1,17 +1,31 @@
 use std::fs;
 
 use crate::execute::foreground;
+use crate::gpu_extension;
 
 const MODPROBE: &str = "/sbin/modprobe";
 
-/// Load a kernel module via modprobe.
-/// For nvidia, automatically disables NVLink when only one GPU is present.
+/// Load a kernel module. Disables NVLink for single-GPU nvidia; NVIDIA modules
+/// come from the `gpu` extension (`--dirname`) when present.
 pub fn load(module: &str) {
-    let mut args = vec![module];
-    if module == "nvidia" && count_nvidia_gpus_from("/sys/bus/pci/devices") == 1 {
-        args.push("NVreg_NvLinkDisable=1");
+    let single_gpu = module == "nvidia" && count_nvidia_gpus_from("/sys/bus/pci/devices") == 1;
+    let dirname = gpu_extension::modprobe_dirname(module);
+    let args = build_args(module, dirname.as_deref(), single_gpu);
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    foreground(MODPROBE, &arg_refs);
+}
+
+fn build_args(module: &str, dirname: Option<&str>, single_gpu: bool) -> Vec<String> {
+    let mut args = Vec::new();
+    if let Some(dir) = dirname {
+        args.push("--dirname".to_owned());
+        args.push(dir.to_owned());
     }
-    foreground(MODPROBE, &args);
+    args.push(module.to_owned());
+    if single_gpu {
+        args.push("NVreg_NvLinkDisable=1".to_owned());
+    }
+    args
 }
 
 fn count_nvidia_gpus_from(pci_path: &str) -> usize {
@@ -62,6 +76,42 @@ mod tests {
             load("nonexistent_module_xyz123");
         });
         assert!(result.is_err());
+    }
+
+    // === build_args ===
+
+    #[test]
+    fn test_build_args_plain() {
+        assert_eq!(build_args("erofs", None, false), vec!["erofs"]);
+    }
+
+    #[test]
+    fn test_build_args_single_gpu() {
+        assert_eq!(
+            build_args("nvidia", None, true),
+            vec!["nvidia", "NVreg_NvLinkDisable=1"]
+        );
+    }
+
+    #[test]
+    fn test_build_args_extension_dirname() {
+        assert_eq!(
+            build_args("nvidia", Some(gpu_extension::ROOT), false),
+            vec!["--dirname", gpu_extension::ROOT, "nvidia"]
+        );
+    }
+
+    #[test]
+    fn test_build_args_extension_dirname_single_gpu() {
+        assert_eq!(
+            build_args("nvidia", Some(gpu_extension::ROOT), true),
+            vec![
+                "--dirname",
+                gpu_extension::ROOT,
+                "nvidia",
+                "NVreg_NvLinkDisable=1"
+            ]
+        );
     }
 
     fn create_pci_device(tmpdir: &TempDir, name: &str, vendor: &str, class: &str) {

--- a/src/smi.rs
+++ b/src/smi.rs
@@ -4,9 +4,14 @@
 //! All are optional—if the kernel param isn't set, they return immediately.
 
 use crate::execute::foreground;
+use crate::gpu_extension;
 use crate::nvrc::NVRC;
 
 const NVIDIA_SMI: &str = "/bin/nvidia-smi";
+
+fn nvidia_smi() -> String {
+    gpu_extension::path(NVIDIA_SMI)
+}
 
 impl NVRC {
     /// Lock memory clocks to a specific frequency (MHz).
@@ -15,7 +20,7 @@ impl NVRC {
         let Some(mhz) = self.nvidia_smi_lmc else {
             return;
         };
-        foreground(NVIDIA_SMI, &["-lmc", &mhz.to_string()]);
+        foreground(&nvidia_smi(), &["-lmc", &mhz.to_string()]);
     }
 
     /// Lock GPU core clocks to a specific frequency (MHz).
@@ -24,7 +29,7 @@ impl NVRC {
         let Some(mhz) = self.nvidia_smi_lgc else {
             return;
         };
-        foreground(NVIDIA_SMI, &["-lgc", &mhz.to_string()]);
+        foreground(&nvidia_smi(), &["-lgc", &mhz.to_string()]);
     }
 
     /// Set GPU power limit in watts.
@@ -33,7 +38,7 @@ impl NVRC {
         let Some(watts) = self.nvidia_smi_pl else {
             return;
         };
-        foreground(NVIDIA_SMI, &["-pl", &watts.to_string()]);
+        foreground(&nvidia_smi(), &["-pl", &watts.to_string()]);
     }
 
     /// Set GPU Ready State after successful attestation.
@@ -44,7 +49,7 @@ impl NVRC {
         let Some(ref state) = self.nvidia_smi_srs else {
             return;
         };
-        foreground(NVIDIA_SMI, &["conf-compute", "-srs", state]);
+        foreground(&nvidia_smi(), &["conf-compute", "-srs", state]);
     }
 }
 

--- a/src/toolkit.rs
+++ b/src/toolkit.rs
@@ -7,20 +7,42 @@
 //! can discover and mount GPU devices without needing the legacy hook.
 
 use crate::execute::foreground;
+use crate::gpu_extension;
 
 const NVIDIA_CTK: &str = "/bin/nvidia-ctk";
 
 /// Run nvidia-ctk with given arguments.
 fn ctk(args: &[&str]) {
-    foreground(NVIDIA_CTK, args);
+    foreground(&gpu_extension::path(NVIDIA_CTK), args);
 }
 
-/// Generate CDI spec for GPU device discovery.
-/// CDI allows container runtimes (containerd, CRI-O) to inject GPU devices
-/// without nvidia-docker. The spec is written to /var/run/cdi/nvidia.yaml
-/// where runtimes expect to find it.
+/// Generate the CDI spec (`/var/run/cdi/nvidia.yaml`) so runtimes can inject GPU
+/// devices without the legacy hook. With composable images the extension-derived
+/// flags point nvidia-ctk at `/run/kata-extensions/gpu`; see the [`gpu_extension`] helpers
+/// for why each is needed (all no-ops for the monolithic image).
 pub fn nvidia_ctk_cdi() {
-    ctk(&["-d", "cdi", "generate", "--output=/var/run/cdi/nvidia.yaml"]);
+    let args = cdi_args(gpu_extension::driver_root(), gpu_extension::cdi_hook_path());
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    ctk(&arg_refs);
+}
+
+/// Assemble the `nvidia-ctk cdi generate` arguments from the (possibly empty)
+/// extension-derived paths.
+fn cdi_args(driver_root: Option<String>, cdi_hook_path: Option<String>) -> Vec<String> {
+    let mut args = vec![
+        "-d".to_owned(),
+        "cdi".to_owned(),
+        "generate".to_owned(),
+        "--output=/var/run/cdi/nvidia.yaml".to_owned(),
+    ];
+    if let Some(root) = driver_root {
+        args.push(format!("--driver-root={root}"));
+        args.push(format!("--dev-root={}", gpu_extension::DEV_ROOT));
+    }
+    if let Some(path) = cdi_hook_path {
+        args.push(format!("--nvidia-cdi-hook-path={path}"));
+    }
+    args
 }
 
 #[cfg(test)]
@@ -44,5 +66,35 @@ mod tests {
             nvidia_ctk_cdi();
         });
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cdi_args_monolithic() {
+        // No extension: only the base generate args, no extension-specific flags.
+        assert_eq!(
+            cdi_args(None, None),
+            vec!["-d", "cdi", "generate", "--output=/var/run/cdi/nvidia.yaml",]
+        );
+    }
+
+    #[test]
+    fn test_cdi_args_with_extension() {
+        let root = gpu_extension::ROOT;
+        let args = cdi_args(
+            Some(root.to_owned()),
+            Some(format!("{root}/bin/nvidia-cdi-hook")),
+        );
+        assert_eq!(
+            args,
+            vec![
+                "-d".to_owned(),
+                "cdi".to_owned(),
+                "generate".to_owned(),
+                "--output=/var/run/cdi/nvidia.yaml".to_owned(),
+                format!("--driver-root={root}"),
+                "--dev-root=/".to_owned(),
+                format!("--nvidia-cdi-hook-path={root}/bin/nvidia-cdi-hook"),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Add guest-side support for the Kata composable VM images proposal
(kata-containers#13029; systemd equivalent merged in kata-containers#13285).
A lean base rootfs ships only NVRC and kata-agent, while purpose-specific
content is cold-plugged as dm-verity/EROFS extension images. NVRC is the init
system for the NVIDIA GPU case and performs the work the systemd
kata-extension-mount@.service unit does in a systemd guest.

Mounting (guest_extension_image):

- discover cold-plugged extension devices by serial extension-<name> via
  /sys/block/*/serial (device-driven) and reconcile them 1:1 with the measured
  kata.extension.<name>.verity_params on the kernel command line
- veritysetup open --no-superblock with those explicit params, then mount the
  verified EROFS read-only (nosuid,nodev) at /run/kata-extensions/<name>/
- fail closed: a device without valid params, params without a device, or a
  missing dm-verity hash partition all panic, powering off the VM via the panic
  hook (matching OnFailure=poweroff.target). Unlike the systemd script there is
  no unmeasured raw-mount fallback (its only user is s390x Secure Execution,
  which NVRC does not target): every extension must be verity-measured.
- runs before disable_modules_loading() so dm-verity/erofs can still load if
  built as modules

GPU userspace (gpu, modprobe, toolkit):

- consume the cold-plugged `gpu` extension mounted at /run/kata-extensions/gpu:
  binaries from <root>/{bin,sbin}, shared libraries from the multiarch dir
  <root>/usr/lib/<triplet> (mirroring the monolithic image), modprobe --dirname
  <root> for NVIDIA modules (in-tree ib_umad/mlx5_ib stay in the base rootfs),
  configs from <root>/usr/share/nvidia, and firmware bind-mounted onto
  /lib/firmware/nvidia for the kernel firmware loader
- rebuild the loader cache from the extension (ldconfig over its lib dir into
  /run, then bind the result over the read-only base /etc/ld.so.cache) so
  kata-agent and the createContainer CDI hooks resolve the GPU libraries without
  an inherited LD_LIBRARY_PATH; NVRC's own GPU tools still get it per-Command,
  never process-global
- teach `nvidia-ctk cdi generate` about the extension layout:
  --nvidia-cdi-hook-path=<root>/bin/nvidia-cdi-hook (else the createContainer
  hooks silently no-op and CUDA fails) and --driver-root=<root> with
  --dev-root=/ so libraries mount at the canonical /usr/lib/<triplet> in the
  container (apps such as NVIDIA NIM scan /usr) without dropping the real guest
  /dev/nvidia* nodes

Attestation (kata-agent):

- inject KATA_ATTESTER_VARIANT=nvidia onto kata-agent when the GPU extension is
  present so it launches the NVIDIA attester and the KBS GPU policy
  (submods.gpu0["ear.status"] == "affirming") can pass

All extension consumption falls back to canonical rootfs paths when no extension
is mounted, so the monolithic NVIDIA image is unchanged. Adds rstest as a
dev-dependency for parametrized tests in the new modules.