### PR TITLE
ci: exempt main.rs from coverage and enforce 90% line minimum

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -63,8 +63,10 @@ jobs:
       # The #[cfg(coverage)] paths in require_root() panic if not run as root,
       # ensuring coverage accurately reflects execution with proper permissions.
       # --test-threads=1 forces serial execution to avoid /dev/log socket conflicts.
+      # src/main.rs is exempt from coverage: dispatch-only plumbing (module
+      # wiring and the mode match) that only runs end-to-end as PID 1 in a VM.
       - name: Generate coverage
-        run: sudo -E env "PATH=$PATH" cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info -- --include-ignored --test-threads=1
+        run: sudo -E env "PATH=$PATH" cargo llvm-cov --all-features --workspace --ignore-filename-regex 'src/main\.rs$' --lcov --output-path lcov.info -- --include-ignored --test-threads=1
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@cfd0633edbd2411b532b808ba7a8b5e04f76d2c8 # v2.3.4
@@ -72,3 +74,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: lcov.info
           format: lcov
+
+      # Gate after the upload so Coveralls still receives the report when the
+      # threshold fails. `report` reuses the profdata from the generate step;
+      # sudo because that data is root-owned.
+      - name: Enforce minimum 90% line coverage
+        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 90 --ignore-filename-regex 'src/main\.rs$'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -77,7 +77,8 @@ jobs:
           format: lcov
 
       # Gate after the upload so Coveralls still receives the report when the
-      # threshold fails. `report` reuses the profdata from the generate step;
-      # sudo because that data is root-owned.
+      # threshold fails. `report` regenerates from the profdata and object
+      # files recorded by the generate step (no test-selection flags exist,
+      # e.g. --workspace); sudo because that data is root-owned.
       - name: Enforce minimum 90% line coverage
-        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 90 --ignore-filename-regex 'src/main\.rs$'
+        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --all-features --fail-under-lines 90 --ignore-filename-regex 'src/main\.rs$'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -34,6 +34,7 @@ jobs:
               - '**/*.lock'
               - 'Cargo.lock'
               - '.cargo/**'
+              - '.github/workflows/coverage.yaml'
 
   coverage:
     name: Code coverage

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -78,7 +78,8 @@ jobs:
 
       # Gate after the upload so Coveralls still receives the report when the
       # threshold fails. `report` regenerates from the profdata and object
-      # files recorded by the generate step (no test-selection flags exist,
-      # e.g. --workspace); sudo because that data is root-owned.
+      # files recorded by the generate step, so build/feature/workspace flags
+      # don't apply (cargo-llvm-cov 0.6.21 rejects them on `report`); sudo
+      # because that data is root-owned.
       - name: Enforce minimum 90% line coverage
-        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --all-features --fail-under-lines 90 --ignore-filename-regex 'src/main\.rs$'
+        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 90 --ignore-filename-regex 'src/main\.rs$'

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ optimization and static linking.
 # Unit tests (requires root for some tests)
 cargo test
 
-# Coverage (requires llvm-cov and root)
-cargo llvm-cov --all-features --workspace
+# Coverage (requires llvm-cov and root; CI enforces >=90% lines, main.rs exempt)
+cargo llvm-cov --all-features --workspace --ignore-filename-regex 'src/main\.rs$' --fail-under-lines 90
 
 # Fuzzing
 cargo +nightly fuzz run kernel_params

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ optimization and static linking.
 cargo test
 
 # Coverage (requires llvm-cov and root; CI enforces >=90% lines, main.rs exempt)
-cargo llvm-cov --all-features --workspace --ignore-filename-regex 'src/main\.rs$' --fail-under-lines 90
+cargo llvm-cov --all-features --workspace --ignore-filename-regex 'src/main\.rs$' --fail-under-lines 90 -- --include-ignored --test-threads=1
 
 # Fuzzing
 cargo +nightly fuzz run kernel_params


### PR DESCRIPTION
main.rs is dispatch-only plumbing that only runs as PID 1 in a VM. The gate runs after the Coveralls upload, so failing reports stay visible.