### PR TITLE
coverage: enforce 90% per-file line coverage

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -55,10 +55,12 @@ jobs:
       # cargo-llvm-cov uses LLVM's native instrumentation for accurate coverage.
       # Unlike tarpaulin (ptrace-based), it properly handles #[cfg(coverage)]
       # conditionals we use to skip code paths that can't run in CI (e.g., reboot).
+      # cargo-llvm-cov pinned >= 0.8: --fail-under-file-lines (per-file gate)
+      # does not exist in the 0.6.x line.
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@60581cd7025e0e855cebd745379013e286d9c787 # v2.64.2
+        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov@0.8.7
 
       # Run as root: some tests require privileged operations (modprobe, /proc writes).
       # The #[cfg(coverage)] paths in require_root() panic if not run as root,
@@ -77,9 +79,10 @@ jobs:
           format: lcov
 
       # Gate after the upload so Coveralls still receives the report when the
-      # threshold fails. `report` regenerates from the profdata and object
-      # files recorded by the generate step, so build/feature/workspace flags
-      # don't apply (cargo-llvm-cov 0.6.21 rejects them on `report`); sudo
-      # because that data is root-owned.
-      - name: Enforce minimum 90% line coverage
-        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 90 --ignore-filename-regex 'src/main\.rs$'
+      # threshold fails. `report` rescores the profdata and object files
+      # recorded by the generate step - feature/workspace selection already
+      # happened at test time, so no such flags here; sudo because that data
+      # is root-owned. The per-file bound stops an aggregate score from
+      # masking under-tested modules.
+      - name: Enforce minimum 90% line coverage (total and per file)
+        run: sudo -E env "PATH=$PATH" cargo llvm-cov report --fail-under-lines 90 --fail-under-file-lines 90 --ignore-filename-regex 'src/main\.rs$'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -15,9 +15,11 @@ concurrency:
 name: Code Coverage
 
 jobs:
-  # Detect if only docs changed - skip CI if so
+  # Detect if only docs changed - skip CI if so. Named uniquely: the CI
+  # workflow also has a "Detect changes" job, and required status checks
+  # match check names globally.
   changes:
-    name: Detect changes
+    name: Detect changes (coverage)
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}

--- a/README.md
+++ b/README.md
@@ -158,8 +158,9 @@ optimization and static linking.
 # Unit tests (requires root for some tests)
 cargo test
 
-# Coverage (requires llvm-cov and root; CI enforces >=90% lines, main.rs exempt)
-cargo llvm-cov --all-features --workspace --ignore-filename-regex 'src/main\.rs$' --fail-under-lines 90 -- --include-ignored --test-threads=1
+# Coverage (requires llvm-cov and root; CI enforces >=90% lines overall and
+# per file, main.rs exempt)
+cargo llvm-cov --all-features --workspace --ignore-filename-regex 'src/main\.rs$' --fail-under-lines 90 --fail-under-file-lines 90 -- --include-ignored --test-threads=1
 
 # Fuzzing
 cargo +nightly fuzz run kernel_params

--- a/src/init.rs
+++ b/src/init.rs
@@ -56,4 +56,23 @@ mod tests {
         as_pid1_with(false, || exited.set(true));
         assert!(exited.get(), "non-PID-1 must report identity and exit");
     }
+
+    // The production guard calls std::process::exit(0), which no in-process
+    // test survives; fork so the child runs the real thing.
+    #[test]
+    fn test_as_pid1_production_guard_exits_zero() {
+        match unsafe { libc::fork() } {
+            0 => {
+                as_pid1();
+                unsafe { libc::_exit(1) } // only reached if the guard fell through
+            }
+            pid if pid > 0 => {
+                let mut status = 0;
+                assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+                assert!(libc::WIFEXITED(status), "guard must exit, not crash");
+                assert_eq!(libc::WEXITSTATUS(status), 0, "guard must exit(0)");
+            }
+            err => panic!("fork failed: {err}"),
+        }
+    }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -58,31 +58,26 @@ mod tests {
     }
 
     // The production guard calls std::process::exit(0), which no in-process
-    // test survives; fork so the child runs the real thing.
+    // test survives; fork so the child runs the real thing. Error handling is
+    // shaped so every line runs on the happy path: test code is instrumented
+    // too, and untaken lines count against the per-file coverage gate.
     #[test]
     fn test_as_pid1_production_guard_exits_zero() {
-        match unsafe { libc::fork() } {
-            0 => {
-                as_pid1();
-                unsafe { libc::_exit(1) } // only reached if the guard fell through
-            }
-            pid if pid > 0 => {
-                let mut status = 0;
-                let waited = loop {
-                    match unsafe { libc::waitpid(pid, &mut status, 0) } {
-                        -1 if std::io::Error::last_os_error().raw_os_error()
-                            == Some(libc::EINTR) =>
-                        {
-                            continue
-                        }
-                        r => break r,
-                    }
-                };
-                assert_eq!(waited, pid, "waitpid: {}", std::io::Error::last_os_error());
-                assert!(libc::WIFEXITED(status), "guard must exit, not crash");
-                assert_eq!(libc::WEXITSTATUS(status), 0, "guard must exit(0)");
-            }
-            _ => panic!("fork failed: {}", std::io::Error::last_os_error()),
+        let pid = unsafe { libc::fork() };
+        if pid == 0 {
+            as_pid1();
+            unsafe { libc::_exit(1) } // only reached if the guard fell through
         }
+        assert!(pid > 0, "fork failed: {}", std::io::Error::last_os_error());
+
+        let mut status = 0;
+        let waited = std::iter::repeat_with(|| unsafe { libc::waitpid(pid, &mut status, 0) })
+            .find(|&r| {
+                r != -1 || std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR)
+            })
+            .expect("repeat_with is infinite");
+        assert_eq!(waited, pid, "waitpid: {}", std::io::Error::last_os_error());
+        assert!(libc::WIFEXITED(status), "guard must exit, not crash");
+        assert_eq!(libc::WEXITSTATUS(status), 0, "guard must exit(0)");
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -68,11 +68,21 @@ mod tests {
             }
             pid if pid > 0 => {
                 let mut status = 0;
-                assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+                let waited = loop {
+                    match unsafe { libc::waitpid(pid, &mut status, 0) } {
+                        -1 if std::io::Error::last_os_error().raw_os_error()
+                            == Some(libc::EINTR) =>
+                        {
+                            continue
+                        }
+                        r => break r,
+                    }
+                };
+                assert_eq!(waited, pid, "waitpid: {}", std::io::Error::last_os_error());
                 assert!(libc::WIFEXITED(status), "guard must exit, not crash");
                 assert_eq!(libc::WEXITSTATUS(status), 0, "guard must exit(0)");
             }
-            err => panic!("fork failed: {err}"),
+            _ => panic!("fork failed: {}", std::io::Error::last_os_error()),
         }
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -58,9 +58,13 @@ mod tests {
     }
 
     // The production guard calls std::process::exit(0), which no in-process
-    // test survives; fork so the child runs the real thing. Error handling is
-    // shaped so every line runs on the happy path: test code is instrumented
-    // too, and untaken lines count against the per-file coverage gate.
+    // test survives; fork so the child runs the real thing. The child allocates
+    // and locks stdio (println!, sha256 of /proc/self/exe), which can deadlock
+    // if another harness thread holds those locks at fork time - so the test
+    // only exists under coverage, where the run is pinned to --test-threads=1.
+    // Error handling is shaped so every line runs on the happy path: test code
+    // is instrumented too, and untaken lines count against the per-file gate.
+    #[cfg(coverage)]
     #[test]
     fn test_as_pid1_production_guard_exits_zero() {
         let pid = unsafe { libc::fork() };

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -145,6 +145,7 @@ fn strip_priority(msg: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::TempDir;
 
     // === strip_priority tests ===
@@ -325,7 +326,9 @@ mod tests {
         try_poll();
     }
 
+    // Serialized with the kmsg test that removes and recreates the same file.
     #[test]
+    #[serial]
     fn test_forward_message_appends_to_syslog_file() {
         crate::test_utils::require_root();
         // Nonce keeps the assertion honest against /run/syslog.log contents

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -317,4 +317,19 @@ mod tests {
         // Just exercise the code path, don't assert success
         let _ = panic::catch_unwind(poll);
     }
+
+    #[test]
+    fn test_try_poll_swallows_errors() {
+        // /dev/log may be foreign (bind fails) or already ours; both must be
+        // non-fatal for the best-effort drain.
+        try_poll();
+    }
+
+    #[test]
+    fn test_forward_message_appends_to_syslog_file() {
+        crate::test_utils::require_root();
+        forward_message("<test> forward_message smoke").unwrap();
+        let content = std::fs::read_to_string(SYSLOG_FILE).unwrap();
+        assert!(content.contains("forward_message smoke"));
+    }
 }

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -328,8 +328,15 @@ mod tests {
     #[test]
     fn test_forward_message_appends_to_syslog_file() {
         crate::test_utils::require_root();
-        forward_message("<test> forward_message smoke").unwrap();
+        // Nonce keeps the assertion honest against /run/syslog.log contents
+        // accumulated by earlier runs on the same machine.
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let marker = format!("<test> forward_message smoke {nonce}");
+        forward_message(&marker).unwrap();
         let content = std::fs::read_to_string(SYSLOG_FILE).unwrap();
-        assert!(content.contains("forward_message smoke"));
+        assert!(content.contains(&marker));
     }
 }


### PR DESCRIPTION
Follow-up to #171, which landed just before this commit was pushed.

The aggregate gate lets weak modules hide behind strong ones: the tree sat at 96.37% total while init.rs was at 80.00% and syslog.rs at 84.09%. This adds --fail-under-file-lines 90 so every module must clear 90% on its own, and closes the two existing gaps:

- init.rs: fork-based test runs the real as_pid1() guard end-to-end, asserting it exits 0 (printing the identity line) instead of falling through to init duties
- syslog.rs: tests for try_poll() (best-effort drain must swallow errors) and forward_message() (root test; writes and verifies /run/syslog.log)

cargo-llvm-cov is pinned to 0.8.7 via install-action v2.82.9 because --fail-under-file-lines does not exist in the 0.6.x line CI previously installed. The README coverage command mirrors the CI gate.