### PR TITLE
test: prove kernel param parsing panics exactly when it should

### DIFF
--- a/.github/workflows/kani.yaml
+++ b/.github/workflows/kani.yaml
@@ -48,6 +48,7 @@ jobs:
               - '**/*.rs'
               - '**/*.toml'
               - 'Cargo.lock'
+              - '.cargo/**'
               - '.github/workflows/kani.yaml'
 
   verify:
@@ -60,7 +61,24 @@ jobs:
         with:
           persist-credentials: false
 
+      # WHY cache + cargo install over model-checking/kani-github-action:
+      # the action is a stale composite (v1.1, 2024) that runs this exact
+      # install via internally UNPINNED actions - SHA-pinning a composite
+      # does not pin its internals. Caching the compiled binaries and the
+      # toolchain bundle removes the recurring compile cost and the
+      # crates.io dependency on warm runs.
+      - name: Cache Kani
+        id: cache-kani
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: |
+            ~/.cargo/bin/kani
+            ~/.cargo/bin/cargo-kani
+            ~/.kani
+          key: kani-${{ env.KANI_VERSION }}-${{ runner.os }}
+
       - name: Install Kani
+        if: steps.cache-kani.outputs.cache-hit != 'true'
         run: |
           cargo install kani-verifier --version "${KANI_VERSION}" --locked
           cargo kani setup

--- a/.github/workflows/kani.yaml
+++ b/.github/workflows/kani.yaml
@@ -85,3 +85,81 @@ jobs:
 
       - name: Verify proof harnesses
         run: cargo kani --lib
+
+  # Proof coverage is a report to read, not a gate: it detects
+  # over-constrained harnesses (a kani::assume that silently excludes the
+  # inputs a proof claims to cover) by listing source regions no harness
+  # ever explored. kani-cov would be the native reporter, but it panics on
+  # multi-harness profiles (model-checking/kani#3542), so the console
+  # region annotations from --coverage are post-processed instead.
+  coverage:
+    name: kani coverage
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Cache Kani
+        id: cache-kani
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: |
+            ~/.cargo/bin/kani
+            ~/.cargo/bin/cargo-kani
+            ~/.kani
+          key: kani-${{ env.KANI_VERSION }}-${{ runner.os }}
+
+      - name: Install Kani
+        if: steps.cache-kani.outputs.cache-hit != 'true'
+        run: |
+          cargo install kani-verifier --version "${KANI_VERSION}" --locked
+          cargo kani setup
+
+      - name: Generate proof coverage
+        run: cargo kani --lib --coverage -Z source-coverage | tee kani-coverage.log
+
+      - name: Report uncovered regions in project files
+        run: |
+          {
+            echo "## Kani proof coverage (src/ only)"
+            echo
+            echo "Regions explored by NO harness - either dead code under"
+            echo "the current proofs or an over-constrained harness"
+            echo "assumption. Regions covered by at least one harness are"
+            echo "omitted, as are dependency and toolchain sources."
+            echo
+            echo '```'
+            # Coverage output lists regions per (file, harness) section:
+            #   src/foo.rs (module::proofs::harness_name)
+            #    * 82:5 - 83:2 UNCOVERED
+            # A region is a true gap only if no harness section covers it.
+            awk '
+              /^[^ ].*\.rs \(/ { file = $1; next }
+              / (COVERED|UNCOVERED)$/ && file ~ /^src\// {
+                key = file " " $2 " " $4
+                if ($NF == "COVERED") covered[key] = 1
+                else seen[key] = 1
+              }
+              END {
+                for (k in seen) if (!(k in covered)) print k
+              }
+            ' kani-coverage.log | sort -t: -k1,1 -k2,2n > never-covered.txt
+            if [ -s never-covered.txt ]; then
+              cat never-covered.txt
+            else
+              echo "all reachable src/ regions covered by at least one harness"
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: kani-coverage
+          path: |
+            kani-coverage.log
+            target/kani/*/kanicov_*/
+          retention-days: 30

--- a/.github/workflows/kani.yaml
+++ b/.github/workflows/kani.yaml
@@ -1,0 +1,69 @@
+# Kani formal verification - model-checks the proof harnesses in src/
+#
+# WHY separate workflow:
+# - CBMC is CPU/memory heavy (minutes per harness) - shouldn't block fast checks
+# - Kani bundles its own pinned nightly toolchain + CBMC, independent of the
+#   repo toolchain, so pinning KANI_VERSION pins the whole verification stack
+#
+# WHY --lib: src modules are compiled into both the lib and the bin target;
+# verifying both would run every harness twice.
+
+name: Kani
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  KANI_VERSION: 0.67.0
+
+jobs:
+  # Only run the (expensive) proofs when code or proofs changed
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.rs'
+              - '**/*.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/kani.yaml'
+
+  verify:
+    name: cargo kani
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install Kani
+        run: |
+          cargo install kani-verifier --version "${KANI_VERSION}" --locked
+          cargo kani setup
+
+      - name: Verify proof harnesses
+        run: cargo kani --lib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ serial_test = "3.2.0"
 confidential = []
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(kani)'] }

--- a/src/kernel_params.rs
+++ b/src/kernel_params.rs
@@ -106,6 +106,92 @@ fn uvm_persistenced_mode(value: &str, ctx: &mut NVRC) {
     debug!("nvrc.uvm.persistence.mode: {enabled}");
 }
 
+/// Kani proof harnesses. NVRC panics by design on invalid state (panic ->
+/// reboot, see ARCHITECTURE.md), so the property is not "no panics" but
+/// "panics exactly when they should": no panic on any valid input, guaranteed
+/// panic on every invalid one.
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    /// Nondeterministic UTF-8 string of at most N bytes. Kani explores every
+    /// byte value and every length, so a harness taking this proves its
+    /// property for ALL strings up to N bytes.
+    fn any_string<const N: usize>() -> String {
+        let bytes: [u8; N] = kani::any();
+        let len: usize = kani::any_where(|l| *l <= N);
+        let s = std::str::from_utf8(&bytes[..len]);
+        kani::assume(s.is_ok());
+        s.unwrap().to_owned()
+    }
+
+    /// parse_boolean is total (no input can panic init) and deny-by-default:
+    /// only the four accepted spellings map to true, everything else is false.
+    /// 8 bytes covers all accepted spellings (longest is "false") plus slack.
+    #[kani::proof]
+    #[kani::unwind(9)]
+    fn parse_boolean_deny_by_default() {
+        let s = any_string::<8>();
+        let parsed = parse_boolean(&s);
+        let accepted = matches!(s.to_ascii_lowercase().as_str(), "on" | "true" | "1" | "yes");
+        assert_eq!(parsed, accepted);
+        kani::cover!(parsed, "a true spelling is reachable");
+        kani::cover!(!parsed, "a false input is reachable");
+    }
+
+    /// Hand-rolled u32-to-decimal: `to_string` drags core::fmt into the
+    /// model, which is prohibitively slow under CBMC.
+    fn decimal_string(mut v: u32) -> String {
+        let mut buf = [b'0'; 10]; // u32::MAX has 10 digits
+        let mut i = buf.len();
+        loop {
+            i -= 1;
+            buf[i] = b'0' + (v % 10) as u8;
+            v /= 10;
+            if v == 0 {
+                break;
+            }
+        }
+        std::str::from_utf8(&buf[i..]).unwrap().to_owned()
+    }
+
+    /// Clock/power parsers store every accepted value losslessly. Bounded to
+    /// 5 digits: GPU clocks (MHz) and power limits (W) never exceed that, and
+    /// proving the full 10-digit decimal codec takes CBMC >30min vs seconds.
+    /// Rejection of ALL malformed strings is proven unbounded below.
+    #[kani::proof]
+    #[kani::unwind(12)]
+    fn smi_parsers_roundtrip_5_digit_values() {
+        let v: u32 = kani::any();
+        kani::assume(v <= 99_999);
+        let s = decimal_string(v);
+        let mut c = NVRC::default();
+        nvidia_smi_lgc(&s, &mut c);
+        nvidia_smi_lmc(&s, &mut c);
+        nvidia_smi_pl(&s, &mut c);
+        assert_eq!(c.nvidia_smi_lgc, Some(v));
+        assert_eq!(c.nvidia_smi_lmc, Some(v));
+        assert_eq!(c.nvidia_smi_pl, Some(v));
+    }
+
+    /// Fail-fast fires: no value that fails u32 parsing can slip through
+    /// silently -- the parser must panic (rebooting the VM by design).
+    #[kani::proof]
+    #[kani::should_panic]
+    #[kani::unwind(9)]
+    fn smi_parser_panics_on_every_invalid_value() {
+        let s = any_string::<8>();
+        kani::assume(s.parse::<u32>().is_err());
+        nvidia_smi_lgc(&s, &mut NVRC::default());
+    }
+
+    // process_kernel_params dispatch harnesses are pending: symbolic bytes
+    // flowing through split_whitespace force CBMC to model UTF-8 char
+    // decoding and Unicode whitespace tables, which does not converge in
+    // CI-viable time. The handlers themselves are proven above; dispatch
+    // stays covered by the kernel_params fuzz target.
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/kernel_params.rs
+++ b/src/kernel_params.rs
@@ -176,13 +176,35 @@ mod proofs {
 
     /// Fail-fast fires: no value that fails u32 parsing can slip through
     /// silently -- the parser must panic (rebooting the VM by design).
+    /// One harness per parser: they are textually identical today, but the
+    /// property must hold per entry point so an edit to one cannot silently
+    /// drop its fail-fast. A should_panic harness dies at the first panic,
+    /// so the three parsers cannot share one harness.
     #[kani::proof]
     #[kani::should_panic]
     #[kani::unwind(9)]
-    fn smi_parser_panics_on_every_invalid_value() {
+    fn smi_lgc_panics_on_every_invalid_value() {
         let s = any_string::<8>();
         kani::assume(s.parse::<u32>().is_err());
         nvidia_smi_lgc(&s, &mut NVRC::default());
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    #[kani::unwind(9)]
+    fn smi_lmc_panics_on_every_invalid_value() {
+        let s = any_string::<8>();
+        kani::assume(s.parse::<u32>().is_err());
+        nvidia_smi_lmc(&s, &mut NVRC::default());
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    #[kani::unwind(9)]
+    fn smi_pl_panics_on_every_invalid_value() {
+        let s = any_string::<8>();
+        kani::assume(s.parse::<u32>().is_err());
+        nvidia_smi_pl(&s, &mut NVRC::default());
     }
 
     // process_kernel_params dispatch harnesses are pending: symbolic bytes


### PR DESCRIPTION
Pilot for Kani formal verification, scoped to kernel_params as the first target since it already has a fuzz target to compare against.

Three proof harnesses behind cfg(kani), verifying both directions of the fail-fast design (panic -> reboot):

- parse_boolean is total and deny-by-default: no input can panic it, and only the four accepted spellings map to true (both outcomes proven reachable via cover checks)
- clock/power parsers round-trip every 5-digit value losslessly (bounded: proving the full 10-digit decimal codec takes CBMC >30min vs ~2min)
- every string that fails u32 parsing is guaranteed to hit the fail-fast panic (should_panic harness, unbounded over all inputs up to 8 bytes)

The kani.yaml workflow pins kani-verifier 0.67.0, which pins the bundled nightly toolchain and CBMC independently of the repo toolchain. Runs on PRs and pushes to main, paths-filtered like the other workflows. Local runtime for the full suite is ~3 minutes.

Not included: process_kernel_params dispatch harnesses. Symbolic bytes through split_whitespace force CBMC to model UTF-8 char decoding and Unicode whitespace tables, which does not converge in CI-viable time; dispatch stays covered by the fuzz target for now.