### PR TITLE
ci: add dependabot ok-to-test and auto-merge workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -27,6 +27,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,39 @@
+name: Auto-merge Dependabot PRs
+
+# Enables auto-merge on every Dependabot PR so GitHub merges it automatically
+# once all required branch-protection checks pass. The actual merge decision
+# stays with GitHub's branch-protection engine - this workflow only flips the
+# flag; it cannot bypass any required check.
+#
+# Security notes:
+#   - pull_request_target runs the BASE branch's workflow file, never PR code.
+#   - The author check uses pull_request.user.login (set by GitHub internally),
+#     not github.actor, which is spoofable via "@dependabot rebase" comments.
+#   - contents:write is scoped to GITHUB_TOKEN (this repo only) and is used
+#     solely to call enablePullRequestAutoMerge via `gh pr merge --auto`.
+#   - No merge happens here; GitHub enforces all required checks first.
+#
+# Pre-requisite: "Allow auto-merge" must be enabled in repository Settings →
+# General. Without it gh pr merge --auto returns an error and the step fails.
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types:
+      - opened
+      - reopened
+      # Re-enable after each rebase: GitHub clears auto-merge on force-push.
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-ok-to-test.yaml
+++ b/.github/workflows/dependabot-ok-to-test.yaml
@@ -15,8 +15,11 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: write
-  issues: write # labels ride the Issues API even on PRs
+  issues: write # labels ride the Issues API even on PRs; pull-requests:write not needed
+
+concurrency:
+  group: dependabot-ok-to-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   label:

--- a/.github/workflows/revoke-ok-to-test.yaml
+++ b/.github/workflows/revoke-ok-to-test.yaml
@@ -23,7 +23,10 @@ concurrency:
 jobs:
   revoke:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    # Skip dependabot: dependabot-ok-to-test re-adds the label on every push,
+    # so revoking and re-adding on the same event creates a race. Dependabot
+    # PRs are pre-approved; only human-authored PRs need the revoke/re-approve cycle.
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') && github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:


### PR DESCRIPTION
## Summary

Two new workflows to fully automate dependabot PRs without requiring manual maintainer intervention.

- **`dependabot-ok-to-test.yaml`**: Ports the `ok-to-test` auto-labeler from [`cncf-tags/container-device-interface-rs`](https://github.com/cncf-tags/container-device-interface-rs/blob/main/.github/workflows/dependabot-ok-to-test.yaml). Labels every dependabot PR (opened, reopened, synchronize) so the E2E self-hosted CI runner fires automatically. Includes `synchronize` so the label is re-added after each dependabot rebase (complementing `revoke-ok-to-test.yaml`).

- **`dependabot-auto-merge.yaml`**: Calls `gh pr merge --auto --squash` on every dependabot PR. GitHub's branch-protection engine holds the actual merge until all required status checks pass -- this workflow only sets the flag.

## Security

- `pull_request_target` runs the base branch's workflow file, never PR code.
- The gate is `pull_request.user.login == 'dependabot[bot]'` -- this is set by GitHub internally and cannot be spoofed (unlike `github.actor`, which any commenter can influence via "@dependabot rebase").
- `contents: write` is scoped to `GITHUB_TOKEN` (this repo only) and is used solely for the auto-merge API call.
- No merge can be triggered on non-dependabot PRs regardless of labels or actor.

## Pre-requisite

**"Allow auto-merge" must be enabled** in repository Settings → General, otherwise the auto-merge step will error. This is a one-time repository configuration.

## Test plan

- [ ] Enable "Allow auto-merge" in repository settings
- [ ] Confirm next dependabot PR is labelled `ok-to-test` automatically
- [ ] Confirm E2E CI runs and, once all required checks pass, the PR is merged without manual action