### PR TITLE
ci: pin cargo tool installs with --locked

### DIFF
--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install cargo-fuzz
         # +nightly: a bare cargo install would pull the pinned toolchain
-        run: cargo +nightly install cargo-fuzz
+        run: cargo +nightly install cargo-fuzz --locked
 
       - name: Run fuzzer - ${{ matrix.target }}
         # WHY max_total_time: prevent infinite runs, control CI costs

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Install pinned Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
-      - run: cargo install cargo-audit
+      - run: cargo install cargo-audit --locked
       - run: cargo audit
 
   # Verify licenses, check for banned dependencies, and audit sources
@@ -118,7 +118,7 @@ jobs:
       - name: Install pinned Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
-      - run: cargo install cargo-deny
+      - run: cargo install cargo-deny --locked
       - run: cargo deny check
 
   # Detect unused dependencies in Cargo.toml
@@ -156,7 +156,7 @@ jobs:
       - name: Install pinned Rust toolchain
         uses: ./.github/actions/rust-toolchain
 
-      - run: cargo install cargo-bloat
+      - run: cargo install cargo-bloat --locked
       - run: cargo bloat --release --all-features -n 20
 
   # Detect undefined behavior in unsafe code using Miri interpreter

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -157,7 +157,7 @@ jobs:
         uses: ./.github/actions/rust-toolchain
 
       - run: cargo install cargo-bloat --locked
-      - run: cargo bloat --release --all-features -n 20
+      - run: cargo bloat --locked --release --all-features -n 20
 
   # Detect undefined behavior in unsafe code using Miri interpreter
   miri:


### PR DESCRIPTION
\`cargo install\` without \`--locked\` resolves the latest versions of transitive dependencies, which can silently pull in crates whose MSRV exceeds the pinned toolchain.

\`kstring v2.0.3\` (requires Rust 1.96) entered the resolution graph as a transitive dependency of \`cargo-audit v0.22.2\` while NVRC is pinned to Rust 1.94, breaking the \`Static checks\` job on PRs #185 and #186.

\`--locked\` instructs cargo to use the tool's own published \`Cargo.lock\`, keeping every transitive dependency at the exact versions the tool was tested with. Applied to \`cargo-audit\`, \`cargo-deny\`, \`cargo-bloat\`, and \`cargo-fuzz\` (\`cargo-udeps\` already used \`--locked\`).