### PR TITLE
ci: restore pull-requests:write on dependabot-ok-to-test

### DIFF
--- a/.github/workflows/dependabot-ok-to-test.yaml
+++ b/.github/workflows/dependabot-ok-to-test.yaml
@@ -15,7 +15,8 @@ on:
       - synchronize
 
 permissions:
-  issues: write # labels ride the Issues API even on PRs; pull-requests:write not needed
+  issues: write        # addLabels endpoint
+  pull-requests: write # required by GitHub when the issue is a pull request
 
 concurrency:
   group: dependabot-ok-to-test-${{ github.event.pull_request.number }}


### PR DESCRIPTION
GitHub requires both `issues=write` and `pull_requests=write` when calling `addLabels` on a pull request via the Issues API; without the latter the call returns 403. Copilot's review suggestion to drop it was incorrect -- confirmed by the `x-accepted-github-permissions: issues=write; pull_requests=write` header in the failure response.