### PR TITLE
test: use async-signal-safe exit in fork test panic hook

### DIFF
--- a/src/kata_agent.rs
+++ b/src/kata_agent.rs
@@ -104,21 +104,26 @@ mod tests {
     use serial_test::serial;
     use std::panic;
 
-    /// Install a panic hook that exits with code 1.
-    /// Required in forked children because Rust's test harness catches panics
-    /// and exits with 0, which breaks our "panic = failure" assertions.
+    /// Forked children need this hook: the test harness catches panics and
+    /// exits 0, defeating the parent's "panic = failure" assertions.
     ///
-    /// Uses libc::write + libc::_exit rather than eprintln! + std::process::exit:
-    /// the latter flush stdio and run atexit handlers, which acquire mutexes that
-    /// another test thread may have held at fork time -- deadlocking the child.
+    /// Raw syscalls only: a parallel test thread may hold a stdio/atexit lock
+    /// at fork time, deadlocking the child on eprintln! or process::exit.
+    /// _exit also skips the atexit coverage dump, hence the explicit flush
+    /// (%p in the profraw pattern keeps child files distinct).
     fn set_test_panic_hook() {
+        #[cfg(coverage)]
+        extern "C" {
+            fn __llvm_profile_write_file() -> libc::c_int;
+        }
+
         panic::set_hook(Box::new(|info| {
             let msg = format!("panic: {info}\n");
-            // SAFETY: write(2, ...) and _exit are async-signal-safe; they
-            // bypass the stdio and atexit locks that can deadlock a forked
-            // child of the multi-threaded test harness.
+            // SAFETY: only async-signal-safe calls; no locks touched after fork.
             unsafe {
                 libc::write(2, msg.as_ptr().cast(), msg.len());
+                #[cfg(coverage)]
+                __llvm_profile_write_file();
                 libc::_exit(1);
             }
         }));

--- a/src/kata_agent.rs
+++ b/src/kata_agent.rs
@@ -107,10 +107,20 @@ mod tests {
     /// Install a panic hook that exits with code 1.
     /// Required in forked children because Rust's test harness catches panics
     /// and exits with 0, which breaks our "panic = failure" assertions.
+    ///
+    /// Uses libc::write + libc::_exit rather than eprintln! + std::process::exit:
+    /// the latter flush stdio and run atexit handlers, which acquire mutexes that
+    /// another test thread may have held at fork time -- deadlocking the child.
     fn set_test_panic_hook() {
         panic::set_hook(Box::new(|info| {
-            eprintln!("panic: {info}");
-            std::process::exit(1);
+            let msg = format!("panic: {info}\n");
+            // SAFETY: write(2, ...) and _exit are async-signal-safe; they
+            // bypass the stdio and atexit locks that can deadlock a forked
+            // child of the multi-threaded test harness.
+            unsafe {
+                libc::write(2, msg.as_ptr().cast(), msg.len());
+                libc::_exit(1);
+            }
         }));
     }
 


### PR DESCRIPTION
`set_test_panic_hook()` called `eprintln!` and `std::process::exit(1)`.
Both acquire stdio locks. In a multi-threaded test harness a parallel test
thread can hold the stderr mutex at the moment `fork()` is called; that mutex
appears locked-by-a-dead-thread in the child and can never be released.
The result is `test_fork_agent_with_timeout` hanging indefinitely, which
blocked the `Static checks / cargo test` job on PR #186 for 6 hours until
the runner cancelled it.

Replace with `libc::write(2, ...)` and `libc::_exit(1)`, which are
async-signal-safe and bypass all stdio/atexit locking.