### PR TITLE
fuzz: fix kernel_params fuzzer crash on validation panics

### DIFF
--- a/fuzz/fuzz_targets/kernel_params.rs
+++ b/fuzz/fuzz_targets/kernel_params.rs
@@ -1,8 +1,8 @@
-//! Fuzz target for kernel command line parameter parsing.
+//! Fuzz kernel command line parsing.
 //!
-//! Tests that arbitrary input to process_kernel_params() doesn't panic.
-//! Catches integer overflows, malformed UTF-8 handling, and edge cases
-//! in split/parse logic.
+//! Fuzzes the try_ variant because cargo-fuzz builds with panic=abort, so
+//! catch_unwind cannot filter the expected validation panics. Err is an
+//! expected rejection; any panic is a real bug and becomes a libFuzzer crash.
 
 #![no_main]
 
@@ -10,29 +10,7 @@ use libfuzzer_sys::fuzz_target;
 use NVRC::nvrc::NVRC;
 
 fuzz_target!(|data: &[u8]| {
-    // Only fuzz valid UTF-8 strings (kernel cmdline is always ASCII/UTF-8)
     if let Ok(input) = std::str::from_utf8(data) {
-        // NVRC is fail-fast: invalid numeric params must panic and reboot the VM.
-        // Swallow only those known validation panics; re-raise anything else so
-        // libFuzzer still catches genuine parser bugs.
-        if let Err(payload) = std::panic::catch_unwind(|| {
-            let mut nvrc = NVRC::default();
-            nvrc.process_kernel_params(Some(input));
-        }) {
-            let msg = payload
-                .downcast_ref::<&str>()
-                .copied()
-                .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
-                .unwrap_or("");
-            const EXPECTED: &[&str] = &[
-                "nvrc.smi.lgc: invalid frequency",
-                "nvrc.smi.lmc: invalid frequency",
-                "nvrc.smi.pl: invalid wattage",
-            ];
-            if !EXPECTED.iter().any(|prefix| msg.starts_with(prefix)) {
-                std::panic::resume_unwind(payload);
-            }
-        }
+        let _ = NVRC::default().try_process_kernel_params(Some(input));
     }
 });
-

--- a/src/kata_agent.rs
+++ b/src/kata_agent.rs
@@ -104,21 +104,26 @@ mod tests {
     use serial_test::serial;
     use std::panic;
 
-    /// Install a panic hook that exits with code 1.
-    /// Required in forked children because Rust's test harness catches panics
-    /// and exits with 0, which breaks our "panic = failure" assertions.
+    /// Forked children need this hook: the test harness catches panics and
+    /// exits 0, defeating the parent's "panic = failure" assertions.
     ///
-    /// Uses libc::write + libc::_exit rather than eprintln! + std::process::exit:
-    /// the latter flush stdio and run atexit handlers, which acquire mutexes that
-    /// another test thread may have held at fork time -- deadlocking the child.
+    /// Raw syscalls only: a parallel test thread may hold a stdio/atexit lock
+    /// at fork time, deadlocking the child on eprintln! or process::exit.
+    /// _exit also skips the atexit coverage dump, hence the explicit flush
+    /// (%p in the profraw pattern keeps child files distinct).
     fn set_test_panic_hook() {
+        #[cfg(coverage)]
+        extern "C" {
+            fn __llvm_profile_write_file() -> libc::c_int;
+        }
+
         panic::set_hook(Box::new(|info| {
             let msg = format!("panic: {info}\n");
-            // SAFETY: write(2, ...) and _exit are async-signal-safe; they
-            // bypass the stdio and atexit locks that can deadlock a forked
-            // child of the multi-threaded test harness.
+            // SAFETY: only async-signal-safe calls; no locks touched after fork.
             unsafe {
                 libc::write(2, msg.as_ptr().cast(), msg.len());
+                #[cfg(coverage)]
+                __llvm_profile_write_file();
                 libc::_exit(1);
             }
         }));

--- a/src/kata_agent.rs
+++ b/src/kata_agent.rs
@@ -107,10 +107,20 @@ mod tests {
     /// Install a panic hook that exits with code 1.
     /// Required in forked children because Rust's test harness catches panics
     /// and exits with 0, which breaks our "panic = failure" assertions.
+    ///
+    /// Uses libc::write + libc::_exit rather than eprintln! + std::process::exit:
+    /// the latter flush stdio and run atexit handlers, which acquire mutexes that
+    /// another test thread may have held at fork time -- deadlocking the child.
     fn set_test_panic_hook() {
         panic::set_hook(Box::new(|info| {
-            eprintln!("panic: {info}");
-            std::process::exit(1);
+            let msg = format!("panic: {info}\n");
+            // SAFETY: write(2, ...) and _exit are async-signal-safe; they
+            // bypass the stdio and atexit locks that can deadlock a forked
+            // child of the multi-threaded test harness.
+            unsafe {
+                libc::write(2, msg.as_ptr().cast(), msg.len());
+                libc::_exit(1);
+            }
         }));
     }
 

--- a/src/kernel_params.rs
+++ b/src/kernel_params.rs
@@ -21,24 +21,34 @@ impl NVRC {
     /// Using kernel params allows configuration without userspace tools—critical
     /// for a minimal init where no config files or environment variables exist.
     pub fn process_kernel_params(&mut self, cmdline: Option<&str>) {
+        self.try_process_kernel_params(cmdline)
+            .unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Result twin of [`Self::process_kernel_params`] for the fuzz target:
+    /// cargo-fuzz builds with panic=abort, so catch_unwind cannot filter the
+    /// expected validation panics there.
+    pub fn try_process_kernel_params(&mut self, cmdline: Option<&str>) -> Result<(), String> {
         let content = match cmdline {
             Some(c) => c.to_owned(),
-            None => fs::read_to_string("/proc/cmdline").expect("read /proc/cmdline"),
+            None => fs::read_to_string("/proc/cmdline")
+                .map_err(|e| format!("read /proc/cmdline: {e}"))?,
         };
 
         for (k, v) in content.split_whitespace().filter_map(|p| p.split_once('=')) {
             match k {
-                "nvrc.log" => nvrc_log(v, self),
+                "nvrc.log" => nvrc_log(v, self)?,
                 "nvrc.uvm.persistence.mode" => uvm_persistenced_mode(v, self),
                 "nvrc.dcgm" => nvrc_dcgm(v, self),
 
                 "nvrc.smi.srs" => nvidia_smi_srs(v, self),
-                "nvrc.smi.lgc" => nvidia_smi_lgc(v, self),
-                "nvrc.smi.lmc" => nvidia_smi_lmc(v, self),
-                "nvrc.smi.pl" => nvidia_smi_pl(v, self),
+                "nvrc.smi.lgc" => nvidia_smi_lgc(v, self)?,
+                "nvrc.smi.lmc" => nvidia_smi_lmc(v, self)?,
+                "nvrc.smi.pl" => nvidia_smi_pl(v, self)?,
                 _ => {}
             }
         }
+        Ok(())
     }
 }
 
@@ -52,7 +62,7 @@ fn nvrc_dcgm(value: &str, ctx: &mut NVRC) {
 
 /// Control log verbosity at runtime. Defaults to off to minimize noise.
 /// Enabling devkmsg allows kernel log output even in minimal init environments.
-fn nvrc_log(value: &str, _ctx: &mut NVRC) {
+fn nvrc_log(value: &str, _ctx: &mut NVRC) -> Result<(), String> {
     let lvl = match value.to_ascii_lowercase().as_str() {
         "off" | "0" | "" => log::LevelFilter::Off,
         "error" => log::LevelFilter::Error,
@@ -65,7 +75,8 @@ fn nvrc_log(value: &str, _ctx: &mut NVRC) {
 
     log::set_max_level(lvl);
     debug!("nvrc.log: {}", log::max_level());
-    fs::write("/proc/sys/kernel/printk_devkmsg", b"on\n").expect("printk_devkmsg");
+    fs::write("/proc/sys/kernel/printk_devkmsg", b"on\n")
+        .map_err(|e| format!("printk_devkmsg: {e}"))
 }
 
 /// Secure Randomization Seed for GPU memory. Passed directly to nvidia-smi.
@@ -76,26 +87,35 @@ fn nvidia_smi_srs(value: &str, ctx: &mut NVRC) {
 
 /// Lock GPU core clocks to a fixed frequency (MHz) for consistent performance.
 /// Eliminates thermal/power throttling variance in benchmarks and latency-sensitive workloads.
-fn nvidia_smi_lgc(value: &str, ctx: &mut NVRC) {
-    let mhz: u32 = value.parse().expect("nvrc.smi.lgc: invalid frequency");
+fn nvidia_smi_lgc(value: &str, ctx: &mut NVRC) -> Result<(), String> {
+    let mhz: u32 = value
+        .parse()
+        .map_err(|e| format!("nvrc.smi.lgc: invalid frequency: {e}"))?;
     debug!("nvrc.smi.lgc: {} MHz (all GPUs)", mhz);
     ctx.nvidia_smi_lgc = Some(mhz);
+    Ok(())
 }
 
 /// Lock memory clocks to a fixed frequency (MHz).
 /// Used alongside lgc for fully deterministic GPU behavior.
-fn nvidia_smi_lmc(value: &str, ctx: &mut NVRC) {
-    let mhz: u32 = value.parse().expect("nvrc.smi.lmc: invalid frequency");
+fn nvidia_smi_lmc(value: &str, ctx: &mut NVRC) -> Result<(), String> {
+    let mhz: u32 = value
+        .parse()
+        .map_err(|e| format!("nvrc.smi.lmc: invalid frequency: {e}"))?;
     debug!("nvrc.smi.lmc: {} MHz (all GPUs)", mhz);
     ctx.nvidia_smi_lmc = Some(mhz);
+    Ok(())
 }
 
 /// Set GPU power limit (Watts). Lower limits reduce heat/power, higher allows peak perf.
 /// Useful for power-constrained environments or thermal management.
-fn nvidia_smi_pl(value: &str, ctx: &mut NVRC) {
-    let watts: u32 = value.parse().expect("nvrc.smi.pl: invalid wattage");
+fn nvidia_smi_pl(value: &str, ctx: &mut NVRC) -> Result<(), String> {
+    let watts: u32 = value
+        .parse()
+        .map_err(|e| format!("nvrc.smi.pl: invalid wattage: {e}"))?;
     debug!("nvrc.smi.pl: {} W (all GPUs)", watts);
     ctx.nvidia_smi_pl = Some(watts);
+    Ok(())
 }
 
 /// UVM persistence mode keeps unified memory state across CUDA context teardowns.
@@ -133,7 +153,7 @@ mod tests {
         log_setup();
         let mut c = NVRC::default();
 
-        nvrc_log("debug", &mut c);
+        nvrc_log("debug", &mut c).unwrap();
         assert!(log_enabled!(log::Level::Debug));
     }
 
@@ -311,51 +331,39 @@ mod tests {
     fn test_nvidia_smi_lgc() {
         let mut c = NVRC::default();
 
-        nvidia_smi_lgc("1500", &mut c);
+        assert!(nvidia_smi_lgc("1500", &mut c).is_ok());
         assert_eq!(c.nvidia_smi_lgc, Some(1500));
 
-        nvidia_smi_lgc("2100", &mut c);
+        assert!(nvidia_smi_lgc("2100", &mut c).is_ok());
         assert_eq!(c.nvidia_smi_lgc, Some(2100));
 
-        // Invalid value should panic
-        let result = panic::catch_unwind(|| {
-            nvidia_smi_lgc("invalid", &mut NVRC::default());
-        });
-        assert!(result.is_err());
+        assert!(nvidia_smi_lgc("invalid", &mut NVRC::default()).is_err());
     }
 
     #[test]
     fn test_nvidia_smi_lmc() {
         let mut c = NVRC::default();
 
-        nvidia_smi_lmc("5001", &mut c);
+        assert!(nvidia_smi_lmc("5001", &mut c).is_ok());
         assert_eq!(c.nvidia_smi_lmc, Some(5001));
 
-        nvidia_smi_lmc("6000", &mut c);
+        assert!(nvidia_smi_lmc("6000", &mut c).is_ok());
         assert_eq!(c.nvidia_smi_lmc, Some(6000));
 
-        // Invalid value should panic
-        let result = panic::catch_unwind(|| {
-            nvidia_smi_lmc("not_a_number", &mut NVRC::default());
-        });
-        assert!(result.is_err());
+        assert!(nvidia_smi_lmc("not_a_number", &mut NVRC::default()).is_err());
     }
 
     #[test]
     fn test_nvidia_smi_pl() {
         let mut c = NVRC::default();
 
-        nvidia_smi_pl("300", &mut c);
+        assert!(nvidia_smi_pl("300", &mut c).is_ok());
         assert_eq!(c.nvidia_smi_pl, Some(300));
 
-        nvidia_smi_pl("450", &mut c);
+        assert!(nvidia_smi_pl("450", &mut c).is_ok());
         assert_eq!(c.nvidia_smi_pl, Some(450));
 
-        // Invalid value should panic
-        let result = panic::catch_unwind(|| {
-            nvidia_smi_pl("abc", &mut NVRC::default());
-        });
-        assert!(result.is_err());
+        assert!(nvidia_smi_pl("abc", &mut NVRC::default()).is_err());
     }
 
     #[test]
@@ -367,6 +375,35 @@ mod tests {
         assert_eq!(c.nvidia_smi_lgc, Some(1500));
         assert_eq!(c.nvidia_smi_lmc, Some(5001));
         assert_eq!(c.nvidia_smi_pl, Some(300));
+    }
+
+    #[test]
+    fn test_try_process_kernel_params_invalid_lgc_is_err() {
+        assert!(NVRC::default()
+            .try_process_kernel_params(Some("nvrc.smi.lgc=bad"))
+            .is_err());
+    }
+
+    #[test]
+    fn test_try_process_kernel_params_invalid_lmc_is_err() {
+        assert!(NVRC::default()
+            .try_process_kernel_params(Some("nvrc.smi.lmc=bad"))
+            .is_err());
+    }
+
+    #[test]
+    fn test_try_process_kernel_params_invalid_pl_is_err() {
+        assert!(NVRC::default()
+            .try_process_kernel_params(Some("nvrc.smi.pl=bad"))
+            .is_err());
+    }
+
+    #[test]
+    fn test_process_kernel_params_invalid_lgc_panics() {
+        let result = panic::catch_unwind(|| {
+            NVRC::default().process_kernel_params(Some("nvrc.smi.lgc=bad"));
+        });
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
cargo-fuzz forces `-C panic=abort` via RUSTFLAGS. With that flag set,
`catch_unwind` is silently a no-op: every `.expect()` in the numeric
parsers aborts the process and libFuzzer records it as a crash.

Introduce `try_process_kernel_params()` returning `Result<(), String>`.
The production API is unchanged: `process_kernel_params()` delegates to
the `try_` variant and `.unwrap_or_else(|e| panic!("{e}"))` preserves
fail-fast behavior. The fuzz target calls `try_process_kernel_params()`
so validation errors (invalid freq/wattage) surface as `Err` and are
ignored; genuine parser bugs still abort and are caught by libFuzzer.