### PR TITLE
ci: correct workflow comment to avoid overstating the race fix

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,9 +1,10 @@
 name: Dependabot automation
 
-# Adds ok-to-test and (for Cargo PRs) enables auto-merge in one workflow so
-# the label is present before ci-on-push.yaml evaluates it. Running both in
-# the same pull_request_target workflow eliminates the race between separate
-# workflows competing on the same event.
+# Adds ok-to-test and (for Cargo PRs) enables auto-merge in one workflow.
+# Previously two separate pull_request_target workflows raced on the same event;
+# ci-on-push.yaml still recovers via the pull_request:labeled re-trigger when
+# the label arrives after the opened event, but consolidating here ensures the
+# label job and auto-merge job share one concurrency slot and one workflow run.
 #
 # Security notes:
 #   - pull_request_target runs the BASE branch's workflow file, never PR code.


### PR DESCRIPTION
The previous comment claimed consolidating into one workflow makes the ok-to-test label "present before ci-on-push.yaml evaluates it" and "eliminates the race". ci-on-push.yaml still recovers via the pull_request:labeled re-trigger; the consolidation eliminates the inter-workflow race between the two pull_request_target jobs, not the dependency on the labeled event itself.


Assisted-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>