### PR TITLE
ci: bypass ok-to-test label gate for dependabot PRs

### DIFF
--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -26,8 +26,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Detect if only docs changed - skip CI if so
-  # Only run if ok-to-test label present (security gate for self-hosted runner)
+  # Detect if only docs changed - skip CI if so.
+  # Gate: ok-to-test label required for human PRs; dependabot bypasses the label.
   changes:
     name: Detect changes
     if: |

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -30,7 +30,9 @@ jobs:
   # Only run if ok-to-test label present (security gate for self-hosted runner)
   changes:
     name: Detect changes
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'ok-to-test') ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
@@ -60,8 +62,11 @@ jobs:
               - '.github/actions/**'
   ci:
     needs: changes
-    # Only run on self-hosted runner if: 1) ok-to-test label present (security), 2) code changed (efficiency)
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') && needs.changes.outputs.code == 'true' }}
+    # Only run on self-hosted runner if: 1) approved (security), 2) code changed (efficiency)
+    if: |
+      needs.changes.outputs.code == 'true' &&
+      (contains(github.event.pull_request.labels.*.name, 'ok-to-test') ||
+       github.event.pull_request.user.login == 'dependabot[bot]')
     permissions:
       contents: read
       packages: write
@@ -79,7 +84,10 @@ jobs:
   ci-complete:
     name: Check CI Result
     needs: [changes, ci]
-    if: always() && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    if: |
+      always() &&
+      (contains(github.event.pull_request.labels.*.name, 'ok-to-test') ||
+       github.event.pull_request.user.login == 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,10 +1,8 @@
 name: Dependabot automation
 
-# Adds ok-to-test and (for Cargo PRs) enables auto-merge in one workflow.
-# Previously two separate pull_request_target workflows raced on the same event;
-# ci-on-push.yaml still recovers via the pull_request:labeled re-trigger when
-# the label arrives after the opened event, but consolidating here ensures the
-# label job and auto-merge job share one concurrency slot and one workflow run.
+# Enables auto-merge for Cargo crate updates. ci-on-push.yaml gates the
+# self-hosted runner via the ok-to-test label for human PRs, but bypasses
+# the label check for dependabot[bot] directly, so no label is needed here.
 #
 # Security notes:
 #   - pull_request_target runs the BASE branch's workflow file, never PR code.
@@ -31,24 +29,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  label:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
-    permissions:
-      issues: write # labels ride the Issues API even on PRs
-      pull-requests: write # labeling a PR checks this scope, not just issues
-    steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: ['ok-to-test'],
-            });
-            core.info('Added ok-to-test: dependabot updates are pre-approved for E2E.');
-
   auto-merge:
     runs-on: ubuntu-latest
     # Only auto-merge Cargo crate updates; GitHub Actions bumps require manual review.


### PR DESCRIPTION
Dependabot is pre-approved for CI; requiring the label creates a race where `ci-on-push.yaml` evaluates the label check before the `label` job in the automation workflow has run. Bypassing the gate for `dependabot[bot]` directly means CI fires on the `opened` event without waiting for a `labeled` re-trigger.

Human PRs still require the `ok-to-test` label - the security gate is intact.