### PR TITLE
fix(nvrc): extend local RPC initialization timeout

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -60,7 +60,7 @@ impl NVRC {
             "/var/run/nvidia-persistenced",
             &gpu_extension::path("/bin/nvidia-persistenced"),
         );
-        kmsg::wait_for_marker(&mut reader, "Local RPC services initialized", 120);
+        kmsg::wait_for_marker(&mut reader, "Local RPC services initialized", 600);
     }
 
     fn spawn_persistenced(&mut self, run_dir: &str, bin: &str) {


### PR DESCRIPTION
Increase the wait timeout for the "Local RPC services initialized" marker from 120 to 600 seconds to accommodate slower NVIDIA NVRC initialization.

Fixes NVIDIA/nvrc#159